### PR TITLE
Utilfun

### DIFF
--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -375,4 +375,35 @@ fun concat_acc_IMP_Minus_loop_time where
 + concat_acc_IMP_Minus_loop_time (append_tail (reverse_nat (hd_nat n)) acc) (tl_nat n)
 "
 
+lemma concat_acc_IMP_Minus_correct:
+  assumes "s ''a'' = 0" "s ''b'' = 0" "s ''c'' = 0" "s ''d'' = 0" "s ''e'' = 0" "s ''f'' = 0"
+    "s ''fst_nat'' = 0" "s ''snd_nat'' = 0" "s ''cons'' = 0"
+    "s ''triangle'' = 0" "s ''prod_encode'' = 0"
+    "s ''reverse_nat_acc'' = 0" "s ''append_tail'' = 0"
+  shows "(WHILE ''n''\<noteq>0 DO concat_acc_IMP_Minus_iteration, s)
+    \<Rightarrow>\<^bsup>concat_acc_IMP_Minus_loop_time (s ''acc'') (s ''n'')\<^esup>
+s(''a'':=0, ''b'':=0, ''c'':=0, ''d'':=0, ''e'':=0, ''f'':=0,
+''fst_nat'' := 0, ''snd_nat'' := 0, ''cons'' := 0,
+  ''triangle'' := 0, ''prod_encode'' := 0,
+  ''reverse_nat_acc'' := 0, ''append_tail'' := 0,
+  ''acc'' := concat_acc (s ''acc'') (s ''n''),
+  ''n'' := 0)"
+  using assms
+proof(induct "s ''acc''" "s ''n''" arbitrary: s rule: concat_acc.induct)
+  case 1
+  show ?case proof(cases "s ''n''")
+    case 0
+    then show ?thesis
+      by(auto simp add: 1
+          intro!: terminates_in_time_state_intro[OF Big_StepT.WhileFalse]
+          )
+    next
+    case (Suc nat)
+    show ?thesis
+      apply(rule terminates_in_time_state_intro[OF Big_StepT.WhileTrue])
+           apply(fastforce simp: Suc intro: 1(1) concat_acc_IMP_Minus_iteration_correct)+
+      done
+  qed
+qed
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -223,4 +223,19 @@ lemma elemof_IMP_Minus_correct:
 
 subsection \<open>remdups_tail\<close>
 
+subsection \<open>list_from_acc\<close>
+
+(* Registers:
+acc: d
+s: e
+n: f
+*)
+definition list_from_acc_IMP_Minus_iteration where
+  "list_from_acc_IMP_Minus_iteration \<equiv>
+  cons_IMP_Minus (V ''e'') (V ''d'') ;;
+  ''d'' ::= (A (V ''cons'')) ;;
+  ''e'' ::= ((V ''e'') \<oplus> (N 1)) ;;
+  ''f'' ::= ((V ''f'') \<ominus> (N 1))
+"
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -173,4 +173,109 @@ fun elemof_IMP_Minus_loop_time :: "nat \<Rightarrow> nat \<Rightarrow> nat" wher
 | "elemof_IMP_Minus_loop_time e l = 1 + elemof_IMP_Minus_iteration_time e l
  + elemof_IMP_Minus_loop_time e (if e = hd_nat l then 0 else (tl_nat l))"
 
+
+lemma elemof_IMP_Minus_loop_correct:
+  assumes "s ''a'' = 0" "s ''b'' = 0" "s ''c'' = 0" "s ''fst_nat'' = 0" "s ''snd_nat'' = 0"
+    shows
+  "(elemof_IMP_Minus_loop, s)
+    \<Rightarrow>\<^bsup>elemof_IMP_Minus_loop_time (s ''e'') (s ''f'')\<^esup>
+  s(''a'' := elemof (s ''e'') (s ''f''),
+    ''b'' := 0,
+    ''c'' := 0,
+    ''f'' := 0,
+    ''fst_nat'' := 0,
+    ''snd_nat'' := 0 )"
+using assms
+proof(induction "s ''e''" "s ''f''" arbitrary: s rule: elemof.induct)
+  case 1
+  then show ?case
+  proof(cases "s ''f''")
+    case 0
+    then have "elemof (s ''e'') (s ''f'') = 0" by simp
+    then have a1: "s =
+s(''a'' := elemof (s ''e'') (s ''f''), ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)"
+      using 0 1 by auto
+
+    from 0 have a2: "Suc (Suc 0) = elemof_IMP_Minus_loop_time (s ''e'') (s ''f'')"
+      by simp
+
+    show ?thesis
+      unfolding elemof_IMP_Minus_loop_def
+      using
+       terminates_in_time_state_intro[OF Big_StepT.WhileFalse a2,
+  of s "''f''", OF 0,
+of "s(''a'' := elemof (s ''e'') (s ''f''), ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)"
+elemof_IMP_Minus_iteration, OF a1
+] by simp
+
+  next
+    case (Suc nat)
+    then have b1: "s ''f'' \<noteq> 0" by simp
+    show ?thesis
+    proof(cases "hd_nat (s ''f'') = s ''e''")
+      case True
+      then show ?thesis unfolding elemof_IMP_Minus_loop_def
+        using Suc
+          terminates_in_time_state_intro[OF Big_StepT.WhileTrue[of s], OF b1
+elemof_IMP_Minus_iteration_correct Big_StepT.WhileFalse ]
+        by simp
+    next
+      case False
+      let ?s1 = "(s ( ''a'' := if s ''e'' = hd_nat (s ''f'') then 1 else 0,
+                      ''b'' := 0, ''c'' := 0,
+                      ''f'' := if s ''e'' = hd_nat (s ''f'') then 0 else tl_nat (s ''f''),
+                      ''fst_nat'' := 0, ''snd_nat'' := 0))"
+
+      have d1: "s ''e'' = ?s1 ''e''" by simp
+
+      have d2: "tl_nat (s ''f'') = ?s1 ''f''" using False by simp
+
+      have d3: "?s1 ''a'' = 0" using False by simp
+      have d4: "?s1 ''b'' = 0" using False by simp
+      have d5: "?s1 ''c'' = 0" using False by simp
+      have d6: "?s1 ''fst_nat'' = 0" using False by simp
+      have d7: "?s1 ''snd_nat'' = 0" using False by simp
+
+      have ih: "(WHILE ''f''\<noteq>0 DO elemof_IMP_Minus_iteration, ?s1)
+        \<Rightarrow>\<^bsup> elemof_IMP_Minus_loop_time (?s1 ''e'') (?s1 ''f'') \<^esup>
+  ?s1(''a'' := elemof (?s1 ''e'') (?s1 ''f''), ''b'' := 0, ''c'' := 0, ''f'' := 0,
+  ''fst_nat'' := 0, ''snd_nat'' := 0)" using 1(1)[OF b1 False d1 d2 d3 d4 d5 d6 d7]
+        unfolding elemof_IMP_Minus_loop_def by fast
+
+      have iht: " elemof_IMP_Minus_loop_time (s ''e'') (s ''f'') = 
+ 1 + elemof_IMP_Minus_iteration_time (s ''e'') (s ''f'')
+ + elemof_IMP_Minus_loop_time (?s1 ''e'') (?s1 ''f'')"
+        using Suc
+        by simp
+
+      from False b1 have d9: "elemof (s ''e'') (tl_nat (s ''f'')) = elemof (s ''e'') (s ''f'')" by simp
+
+      have "s(
+          ''a'' := if s ''e'' = hd_nat (s ''f'') then 1 else 0, ''b'' := 0, ''c'' := 0,
+          ''f'' := if s ''e'' = hd_nat (s ''f'') then 0 else tl_nat (s ''f''),
+    ''fst_nat'' := 0, ''snd_nat'' := 0,
+    ''a'' := elemof
+       ((s(''a'' := if s ''e'' = hd_nat (s ''f'') then 1 else 0, ''b'' := 0, ''c'' := 0,
+           ''f'' := if s ''e'' = hd_nat (s ''f'') then 0 else tl_nat (s ''f''), ''fst_nat'' := 0, ''snd_nat'' := 0))
+         ''e'')
+       ((s(''a'' := if s ''e'' = hd_nat (s ''f'') then 1 else 0, ''b'' := 0, ''c'' := 0,
+           ''f'' := if s ''e'' = hd_nat (s ''f'') then 0 else tl_nat (s ''f''), ''fst_nat'' := 0, ''snd_nat'' := 0))
+         ''f''),
+    ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)
+= s(
+    ''a'' := elemof (s ''e'') (s ''f''),
+    ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)" using d9 False by simp
+
+
+      then
+      show ?thesis unfolding elemof_IMP_Minus_loop_def
+        using
+terminates_in_time_state_intro[OF Big_StepT.WhileTrue[of s], OF b1
+elemof_IMP_Minus_iteration_correct ih iht[symmetric] refl
+] by blast
+
+    qed
+  qed
+qed
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -288,31 +288,15 @@ proof(induct "s ''d''" "s ''e''" "s ''f''" arbitrary: s rule: list_from_acc.indu
   case 1
   show ?case
   proof(cases "s ''f''")
-    case 0
-    then show ?thesis
+    case 0 then show ?thesis
       by(auto simp add: 1 intro!: terminates_in_time_state_intro[OF Big_StepT.WhileFalse])
   next
     case (Suc nat)
     show ?thesis
-      apply(rule terminates_in_state_intro[OF Big_StepT.WhileTrue])
-          apply(simp add: Suc)
-         apply(rule list_from_acc_IMP_Minus_iteration_correct)
-        apply(simp add: 1 Suc)
-        apply(rule 1(1))
-                 apply(simp add: Suc)
-                apply(simp add: 1 Suc)
-               apply(simp add: 1 Suc)
-              apply(simp add: 1 Suc)
-             apply(simp add: 1 Suc)
-            apply(simp add: 1 Suc)
-           apply(simp add: 1 Suc)
-          apply(simp add: 1 Suc)
-         apply(simp add: 1 Suc)
-        apply(simp add: 1 Suc)
-       apply (subst Suc)
-       apply(subst list_from_acc_IMP_Minus_loop_time.simps(2))
-       apply simp
-      apply(simp add: 1 Suc)
+      apply(rule terminates_in_time_state_intro[OF Big_StepT.WhileTrue])
+           apply(fastforce
+          simp add: 1 Suc
+          intro: 1(1) list_from_acc_IMP_Minus_iteration_correct)+
       done
   qed
 qed

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -1,0 +1,5 @@
+theory IMP_Minus_Common_Funs_Nat
+  imports Main
+begin
+
+end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -75,81 +75,24 @@ lemma elemof_IMP_Minus_iteration_correct:
     ''snd_nat'' := 0)"
 proof(cases "hd_nat (s ''f'') = s ''e''")
   case True
-  then have "fst_nat (s ''f'' - Suc 0) - s ''e'' +
-        (s ''e'' -
-         fst_nat (s ''f'' - Suc 0)) = 0" 
-    using hd_nat_def by auto
   then show ?thesis
     unfolding elemof_IMP_Minus_iteration_def
       elemof_IMP_Minus_iteration_time_def
-    by (fastforce simp: True
-        intro: terminates_in_time_state_intro[OF Big_StepT.Assign]
-        terminates_in_time_state_intro[OF Big_StepT.IfFalse]
-        terminates_in_time_state_intro[OF zero_variables_correct]
-        terminates_in_time_state_intro[OF IMP_Minus_fst_nat_correct]
+    by (fastforce simp: hd_nat_def
+        intro!: terminates_in_time_state_intro[OF Seq']
+        intro:zero_variables_correct IMP_Minus_fst_nat_correct
         )+
 next
   case False
-  then have 1: "fst_nat (s ''f'' - Suc 0) - s ''e'' +
-        (s ''e'' -
-         fst_nat (s ''f'' - Suc 0)) \<noteq> 0" 
-    using hd_nat_def by auto
-  then have 0: "(s(''c'' := 0, ''fst_nat'' := fst_nat (s ''f'' - Suc 0), ''b'' := s ''e'' - fst_nat (s ''f'' - Suc 0),
-   ''a'' := fst_nat (s ''f'' - Suc 0) - s ''e'' + (s ''e'' - fst_nat (s ''f'' - Suc 0))))
- ''a'' \<noteq> 0" by simp
-
-  have 2: "( ''a'' ::= (V ''f'' \<ominus> N 1);;
-          IMP_Minus_snd_nat;;
-          ''f'' ::= A (V ''snd_nat''),
-    s(''c'' := 0,
-      ''fst_nat'' := fst_nat (s ''f'' - Suc 0),
-      ''b'' := s ''e'' - fst_nat (s ''f'' - Suc 0),
-      ''a'' := fst_nat (s ''f'' - Suc 0) - s ''e'' +
-              (s ''e'' - fst_nat (s ''f'' - Suc 0))
-      )    )
-     \<Rightarrow>\<^bsup> 2 + IMP_Minus_fst_nat_time (s ''f'' - 1) + 2 \<^esup>
-      s(''a'' := 0, ''b'' := 0, ''c'' := 0,
-        ''f'' := snd_nat (s ''f'' - Suc 0),
-        ''fst_nat'' := fst_nat (s ''f'' - Suc 0),
-        ''snd_nat'' := snd_nat (s ''f'' - 1))"
-    by (auto simp: hd_nat_def
-        intro!: terminates_in_time_state_intro[OF Seq']
-      intro: IMP_Minus_snd_nat_correct)
-
-  have 3: "2 + IMP_Minus_fst_nat_time (s ''f'' - 1) + 2 + 1 =
-  (if s ''e'' = hd_nat (s ''f'') then 2 + 2 + 1
-    else 2 + IMP_Minus_fst_nat_time (s ''f'' - 1) + 2 + 1
-  )"
-    using False by simp
-
-  show ?thesis
+  then show ?thesis
     unfolding elemof_IMP_Minus_iteration_def
-        elemof_IMP_Minus_iteration_time_def
-    apply(rule Seq')+
-    apply(fastforce
-        intro: terminates_in_time_state_intro[OF Big_StepT.Assign]
-        )
-    apply(fastforce
-        intro: terminates_in_time_state_intro[OF IMP_Minus_fst_nat_correct]
-        )
-    apply(fastforce
-        intro: terminates_in_time_state_intro[OF Big_StepT.Assign]
+      elemof_IMP_Minus_iteration_time_def
+    by (fastforce simp: hd_nat_def tl_nat_def 
+        intro!: terminates_in_time_state_intro[OF Seq']
+        intro: zero_variables_correct
+        IMP_Minus_fst_nat_correct
+        IMP_Minus_snd_nat_correct
         )+
-     apply(fastforce simp add: False 1
-        intro!: terminates_in_time_state_intro[OF Big_StepT.IfTrue ,
-        of "s
-   (''c'' := 0, ''fst_nat'' := fst_nat (s ''f'' - Suc 0), ''b'' := s ''e'' - fst_nat (s ''f'' - Suc 0),
-    ''a'' := fst_nat (s ''f'' - Suc 0) - s ''e'' + (s ''e'' - fst_nat (s ''f'' - Suc 0)))"
-        "''a''"
-        "''a'' ::= (V ''f'' \<ominus> N 1);; IMP_Minus_snd_nat;; ''f'' ::= A (V ''snd_nat'')"
-      , OF 0 2 3[symmetric]
-        ])
-    using False
-    apply simp
-    apply(fastforce simp add: tl_nat_def
-        intro: terminates_in_time_state_intro[OF zero_variables_correct]
-        )
-    done
 qed
 
 

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -64,4 +64,104 @@ definition elemof_IMP_Minus_iteration_time where
 ) +
   zero_variables_time [''b'', ''c'', ''fst_nat'', ''snd_nat'']"
 
+lemma elemof_IMP_Minus_iteration_correct:
+  "(elemof_IMP_Minus_iteration, s)
+    \<Rightarrow>\<^bsup>elemof_IMP_Minus_iteration_time (s ''e'') (s ''f'')\<^esup>
+  s(''a'' := (if (s ''e'') = hd_nat (s ''f'') then 1 else 0),
+    ''b'' := 0,
+    ''c'' := 0,
+    ''f'' := (if (s ''e'') = hd_nat (s ''f'') then 0 else (tl_nat (s ''f''))),
+    ''fst_nat'' := 0,
+    ''snd_nat'' := 0)"
+proof(cases "hd_nat (s ''f'') = s ''e''")
+  case True
+  then have 1: "fst_nat (s ''f'' - Suc 0) - s ''e'' +
+        (s ''e'' -
+         fst_nat (s ''f'' - Suc 0)) = 0" 
+    using hd_nat_def by auto
+
+  show ?thesis
+    unfolding elemof_IMP_Minus_iteration_def
+        elemof_IMP_Minus_iteration_time_def
+    apply(rule Seq')+
+    apply(fastforce
+        intro: terminates_in_time_state_intro[OF Big_StepT.Assign]
+        )
+    apply(fastforce
+        intro: terminates_in_time_state_intro[OF IMP_Minus_fst_nat_correct]
+        )
+    apply(fastforce
+        intro: terminates_in_time_state_intro[OF Big_StepT.Assign]
+        )+
+     apply(fastforce simp: True 1
+        intro: terminates_in_time_state_intro[OF Big_StepT.IfFalse]
+        )
+    apply(fastforce simp add: True
+        intro: terminates_in_time_state_intro[OF zero_variables_correct]
+        )
+    done
+next
+  case False
+  then have 1: "fst_nat (s ''f'' - Suc 0) - s ''e'' +
+        (s ''e'' -
+         fst_nat (s ''f'' - Suc 0)) \<noteq> 0" 
+    using hd_nat_def by auto
+  then have 0: "(s(''c'' := 0, ''fst_nat'' := fst_nat (s ''f'' - Suc 0), ''b'' := s ''e'' - fst_nat (s ''f'' - Suc 0),
+   ''a'' := fst_nat (s ''f'' - Suc 0) - s ''e'' + (s ''e'' - fst_nat (s ''f'' - Suc 0))))
+ ''a'' \<noteq> 0" by simp
+
+  have 2: "( ''a'' ::= (V ''f'' \<ominus> N 1);;
+          IMP_Minus_snd_nat;;
+          ''f'' ::= A (V ''snd_nat''),
+    s(''c'' := 0,
+      ''fst_nat'' := fst_nat (s ''f'' - Suc 0),
+      ''b'' := s ''e'' - fst_nat (s ''f'' - Suc 0),
+      ''a'' := fst_nat (s ''f'' - Suc 0) - s ''e'' +
+              (s ''e'' - fst_nat (s ''f'' - Suc 0))
+      )    )
+     \<Rightarrow>\<^bsup> 2 + IMP_Minus_fst_nat_time (s ''f'' - 1) + 2 \<^esup>
+      s(''a'' := 0, ''b'' := 0, ''c'' := 0,
+        ''f'' := snd_nat (s ''f'' - Suc 0),
+        ''fst_nat'' := fst_nat (s ''f'' - Suc 0),
+        ''snd_nat'' := snd_nat (s ''f'' - 1))"
+    by (auto simp: hd_nat_def
+        intro!: terminates_in_time_state_intro[OF Seq']
+      intro: IMP_Minus_snd_nat_correct)
+
+  have 3: "2 + IMP_Minus_fst_nat_time (s ''f'' - 1) + 2 + 1 =
+  (if s ''e'' = hd_nat (s ''f'') then 2 + 2 + 1
+    else 2 + IMP_Minus_fst_nat_time (s ''f'' - 1) + 2 + 1
+  )"
+    using False by simp
+
+  show ?thesis
+    unfolding elemof_IMP_Minus_iteration_def
+        elemof_IMP_Minus_iteration_time_def
+    apply(rule Seq')+
+    apply(fastforce
+        intro: terminates_in_time_state_intro[OF Big_StepT.Assign]
+        )
+    apply(fastforce
+        intro: terminates_in_time_state_intro[OF IMP_Minus_fst_nat_correct]
+        )
+    apply(fastforce
+        intro: terminates_in_time_state_intro[OF Big_StepT.Assign]
+        )+
+     apply(fastforce simp add: False 1
+        intro!: terminates_in_time_state_intro[OF Big_StepT.IfTrue ,
+        of "s
+   (''c'' := 0, ''fst_nat'' := fst_nat (s ''f'' - Suc 0), ''b'' := s ''e'' - fst_nat (s ''f'' - Suc 0),
+    ''a'' := fst_nat (s ''f'' - Suc 0) - s ''e'' + (s ''e'' - fst_nat (s ''f'' - Suc 0)))"
+        "''a''"
+        "''a'' ::= (V ''f'' \<ominus> N 1);; IMP_Minus_snd_nat;; ''f'' ::= A (V ''snd_nat'')"
+      , OF 0 2 3[symmetric]
+        ])
+    using False
+    apply simp
+    apply(fastforce simp add: False tl_nat_def
+        intro: terminates_in_time_state_intro[OF zero_variables_correct]
+        )
+    done
+qed
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -158,7 +158,7 @@ next
         ])
     using False
     apply simp
-    apply(fastforce simp add: False tl_nat_def
+    apply(fastforce simp add: tl_nat_def
         intro: terminates_in_time_state_intro[OF zero_variables_correct]
         )
     done

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -75,31 +75,19 @@ lemma elemof_IMP_Minus_iteration_correct:
     ''snd_nat'' := 0)"
 proof(cases "hd_nat (s ''f'') = s ''e''")
   case True
-  then have 1: "fst_nat (s ''f'' - Suc 0) - s ''e'' +
+  then have "fst_nat (s ''f'' - Suc 0) - s ''e'' +
         (s ''e'' -
          fst_nat (s ''f'' - Suc 0)) = 0" 
     using hd_nat_def by auto
-
-  show ?thesis
+  then show ?thesis
     unfolding elemof_IMP_Minus_iteration_def
-        elemof_IMP_Minus_iteration_time_def
-    apply(rule Seq')+
-    apply(fastforce
+      elemof_IMP_Minus_iteration_time_def
+    by (fastforce simp: True
         intro: terminates_in_time_state_intro[OF Big_StepT.Assign]
-        )
-    apply(fastforce
-        intro: terminates_in_time_state_intro[OF IMP_Minus_fst_nat_correct]
-        )
-    apply(fastforce
-        intro: terminates_in_time_state_intro[OF Big_StepT.Assign]
+        terminates_in_time_state_intro[OF Big_StepT.IfFalse]
+        terminates_in_time_state_intro[OF zero_variables_correct]
+        terminates_in_time_state_intro[OF IMP_Minus_fst_nat_correct]
         )+
-     apply(fastforce simp: True 1
-        intro: terminates_in_time_state_intro[OF Big_StepT.IfFalse]
-        )
-    apply(fastforce simp add: True
-        intro: terminates_in_time_state_intro[OF zero_variables_correct]
-        )
-    done
 next
   case False
   then have 1: "fst_nat (s ''f'' - Suc 0) - s ''e'' +

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -49,7 +49,93 @@ definition append_tail_IMP_Minus_time where
 + zero_variables_time [''a'', ''b'', ''c'', ''d'', ''e'', ''f'', ''fst_nat'', ''snd_nat'', ''cons'',
     ''triangle'', ''prod_encode'', ''reverse_nat_acc'']"
 
+lemma x: "
+(\<lambda> v . if v = st then 0 else s v)
+= (s(st := 0))
+" by auto
 
+lemma append_tail_IMP_Minus_correct:
+  "(append_tail_IMP_Minus, s)
+    \<Rightarrow>\<^bsup>append_tail_IMP_Minus_time (s ''e'') (s ''f'')\<^esup>
+  s(''a'':=0, ''b'':=0, ''c'':=0, ''d'':=0, ''e'':=0, ''f'':=0,
+    ''fst_nat'':=0, ''snd_nat'':=0, ''cons'':=0,
+    ''triangle'':=0, ''prod_encode'':=0, ''reverse_nat_acc'':=0,
+    ''append_tail'':= append_tail (s ''e'') (s ''f''))"
+  unfolding append_tail_IMP_Minus_def append_tail_IMP_Minus_time_def
+  apply(rule Seq')+
+             apply(simp add: numeral_2_eq_2)
+             apply(rule terminates_in_state_intro[OF Big_StepT.Assign])
+             apply (rule refl)
+            apply(simp add: numeral_2_eq_2)
+            apply(rule terminates_in_state_intro[OF Big_StepT.Assign])
+            apply simp
+           apply(simp add: numeral_2_eq_2)
+           apply(rule terminates_in_state_intro[OF Big_StepT.Assign])
+           apply simp
+          apply(rule terminates_in_time_state_intro[OF reverse_nat_acc_IMP_Minus_correct])
+           apply simp apply (simp del: reverse_nat_acc.simps)
+         apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
+          apply simp apply (simp del: reverse_nat_acc.simps)
+        apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
+         apply simp apply (simp del: reverse_nat_acc.simps)
+       apply(rule terminates_in_time_state_intro[OF reverse_nat_acc_IMP_Minus_correct])
+
+        apply (simp) apply (simp del: reverse_nat_acc.simps)
+      apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
+       apply simp apply (simp del: reverse_nat_acc.simps)
+     apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
+      apply simp apply (simp del: reverse_nat_acc.simps)
+    apply(rule terminates_in_time_state_intro[OF reverse_nat_acc_IMP_Minus_correct])
+     apply simp apply (simp del: reverse_nat_acc.simps)
+   apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
+    apply simp apply (simp del: reverse_nat_acc.simps)
+  apply(rule terminates_in_state_intro[OF zero_variables_correct])
+  apply (subst append_tail_def)
+  apply(subst revapp)
+  apply(subst reverse_nat_def)
+  apply(subst reverse_nat_def)
+  using x fun_upd_twist
+proof -
+  have " (\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''d'', ''e'', ''f'', ''fst_nat'', ''snd_nat'', ''cons'', ''triangle'', ''prod_encode'', ''reverse_nat_acc''] then 0
+          else (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0, ''triangle'' := 0, ''prod_encode'' := 0, ''cons'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
+                  ''reverse_nat_acc'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f'')),
+                  ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f''))))
+                v)
+=
+(\<lambda>v. if v = ''reverse_nat_acc'' then 0
+          else (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0,
+ ''fst_nat'' := 0, ''snd_nat'' := 0, ''cons'' := 0, ''triangle'' := 0, ''prod_encode'' := 0,
+  ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f''))
+))
+v)
+" by auto
+
+  also have "\<dots> =
+  (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0,
+ ''fst_nat'' := 0, ''snd_nat'' := 0, ''cons'' := 0, ''triangle'' := 0, ''prod_encode'' := 0,
+  ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f'')),
+''reverse_nat_acc'' := 0
+))
+" using x[of "''reverse_nat_acc''" ]  .
+
+  also have "\<dots> =
+  (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0,
+ ''fst_nat'' := 0, ''snd_nat'' := 0, ''cons'' := 0, ''triangle'' := 0, ''prod_encode'' := 0,
+''reverse_nat_acc'' := 0,
+  ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f''))
+))
+" by (simp add: fun_upd_twist)
+
+
+  finally show "(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''d'', ''e'', ''f'', ''fst_nat'', ''snd_nat'', ''cons'', ''triangle'', ''prod_encode'', ''reverse_nat_acc''] then 0
+          else (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0, ''triangle'' := 0, ''prod_encode'' := 0, ''cons'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
+                  ''reverse_nat_acc'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f'')),
+                  ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f''))))
+                v) =
+    s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0, ''cons'' := 0, ''triangle'' := 0, ''prod_encode'' := 0,
+      ''reverse_nat_acc'' := 0, ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f'')))"
+    by simp
+qed
 
 
 subsection \<open>elemof\<close>

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -226,21 +226,11 @@ elemof_IMP_Minus_iteration_correct Big_StepT.WhileFalse ]
                       ''f'' := if s ''e'' = hd_nat (s ''f'') then 0 else tl_nat (s ''f''),
                       ''fst_nat'' := 0, ''snd_nat'' := 0))"
 
-      have d1: "s ''e'' = ?s1 ''e''" by simp
-
-      have d2: "tl_nat (s ''f'') = ?s1 ''f''" using False by simp
-
-      have d3: "?s1 ''a'' = 0" using False by simp
-      have d4: "?s1 ''b'' = 0" using False by simp
-      have d5: "?s1 ''c'' = 0" using False by simp
-      have d6: "?s1 ''fst_nat'' = 0" using False by simp
-      have d7: "?s1 ''snd_nat'' = 0" using False by simp
-
       have ih: "(WHILE ''f''\<noteq>0 DO elemof_IMP_Minus_iteration, ?s1)
         \<Rightarrow>\<^bsup> elemof_IMP_Minus_loop_time (?s1 ''e'') (?s1 ''f'') \<^esup>
   ?s1(''a'' := elemof (?s1 ''e'') (?s1 ''f''), ''b'' := 0, ''c'' := 0, ''f'' := 0,
-  ''fst_nat'' := 0, ''snd_nat'' := 0)" using 1(1)[OF b1 False d1 d2 d3 d4 d5 d6 d7]
-        unfolding elemof_IMP_Minus_loop_def by fast
+  ''fst_nat'' := 0, ''snd_nat'' := 0)" using 1(1)[OF b1 False, of ?s1] False
+        unfolding elemof_IMP_Minus_loop_def by simp
 
       have iht: " elemof_IMP_Minus_loop_time (s ''e'') (s ''f'') = 
  1 + elemof_IMP_Minus_iteration_time (s ''e'') (s ''f'')
@@ -248,9 +238,9 @@ elemof_IMP_Minus_iteration_correct Big_StepT.WhileFalse ]
         using Suc
         by simp
 
-      from False b1 have d9: "elemof (s ''e'') (tl_nat (s ''f'')) = elemof (s ''e'') (s ''f'')" by simp
+      from False b1 have "elemof (s ''e'') (tl_nat (s ''f'')) = elemof (s ''e'') (s ''f'')" by simp
 
-      have "s(
+      then have "s(
           ''a'' := if s ''e'' = hd_nat (s ''f'') then 1 else 0, ''b'' := 0, ''c'' := 0,
           ''f'' := if s ''e'' = hd_nat (s ''f'') then 0 else tl_nat (s ''f''),
     ''fst_nat'' := 0, ''snd_nat'' := 0,
@@ -264,7 +254,7 @@ elemof_IMP_Minus_iteration_correct Big_StepT.WhileFalse ]
     ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)
 = s(
     ''a'' := elemof (s ''e'') (s ''f''),
-    ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)" using d9 False by simp
+    ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)" using False by simp
 
 
       then

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -261,4 +261,10 @@ lemma list_from_acc_IMP_Minus_iteration_correct:
       intro!: terminates_in_time_state_intro[OF Seq']
       intro: cons_IMP_Minus_correct)+
 
+fun list_from_acc_IMP_Minus_loop_time where
+  "list_from_acc_IMP_Minus_loop_time acc s 0 = 2"
+| "list_from_acc_IMP_Minus_loop_time acc s (Suc n) =
+  1 + list_from_acc_IMP_Minus_iteration_time s acc
+  + list_from_acc_IMP_Minus_loop_time (s##acc) (s+1) n"
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -1,5 +1,5 @@
 theory IMP_Minus_Common_Funs_Nat
-  imports Main
+  imports "../../IMP-/IMP_Minus_Nat_Bijection"
 begin
 
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -57,10 +57,10 @@ WHILE 0/=l DO
 
 definition elemof_IMP_Minus_iteration_time where
 "elemof_IMP_Minus_iteration_time e l \<equiv>
-  2 + IMP_Minus_fst_nat_time (l - 1) + 2 + 2 + 2 +
-  (if e = hd_nat l then  2 + 2 + 1
+  8 + IMP_Minus_fst_nat_time (l - 1) +
+  (if e = hd_nat l then 5
   else
-    2 + IMP_Minus_fst_nat_time (l - 1) + 2 + 1
+    5 + IMP_Minus_fst_nat_time (l - 1)
 ) +
   zero_variables_time [''b'', ''c'', ''fst_nat'', ''snd_nat'']"
 

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -121,80 +121,29 @@ proof(induction "s ''e''" "s ''f''" arbitrary: s rule: elemof.induct)
   case 1
   then show ?case
   proof(cases "s ''f''")
-    case 0
-    then have "elemof (s ''e'') (s ''f'') = 0" by simp
-    then have a1: "s =
-s(''a'' := elemof (s ''e'') (s ''f''), ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)"
-      using 0 1 by auto
-
-    from 0 have a2: "Suc (Suc 0) = elemof_IMP_Minus_loop_time (s ''e'') (s ''f'')"
-      by simp
-
-    show ?thesis
+    case 0 then show ?thesis
       unfolding elemof_IMP_Minus_loop_def
-      using
-       terminates_in_time_state_intro[OF Big_StepT.WhileFalse a2,
-  of s "''f''", OF 0,
-of "s(''a'' := elemof (s ''e'') (s ''f''), ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)"
-elemof_IMP_Minus_iteration, OF a1
-] by simp
-
+      by(auto simp: numeral_2_eq_2 1
+          intro!: terminates_in_state_intro[OF Big_StepT.WhileFalse])
   next
     case (Suc nat)
-    then have b1: "s ''f'' \<noteq> 0" by simp
     show ?thesis
     proof(cases "hd_nat (s ''f'') = s ''e''")
       case True
       then show ?thesis unfolding elemof_IMP_Minus_loop_def
         using Suc
-          terminates_in_time_state_intro[OF Big_StepT.WhileTrue[of s], OF b1
-elemof_IMP_Minus_iteration_correct Big_StepT.WhileFalse ]
+          terminates_in_time_state_intro[OF Big_StepT.WhileTrue[of s], OF _
+            elemof_IMP_Minus_iteration_correct Big_StepT.WhileFalse ]
         by simp
     next
       case False
-      let ?s1 = "(s ( ''a'' := if s ''e'' = hd_nat (s ''f'') then 1 else 0,
-                      ''b'' := 0, ''c'' := 0,
-                      ''f'' := if s ''e'' = hd_nat (s ''f'') then 0 else tl_nat (s ''f''),
-                      ''fst_nat'' := 0, ''snd_nat'' := 0))"
-
-      have ih: "(WHILE ''f''\<noteq>0 DO elemof_IMP_Minus_iteration, ?s1)
-        \<Rightarrow>\<^bsup> elemof_IMP_Minus_loop_time (?s1 ''e'') (?s1 ''f'') \<^esup>
-  ?s1(''a'' := elemof (?s1 ''e'') (?s1 ''f''), ''b'' := 0, ''c'' := 0, ''f'' := 0,
-  ''fst_nat'' := 0, ''snd_nat'' := 0)" using 1(1)[OF b1 False, of ?s1] False
-        unfolding elemof_IMP_Minus_loop_def by simp
-
-      have iht: " elemof_IMP_Minus_loop_time (s ''e'') (s ''f'') = 
- 1 + elemof_IMP_Minus_iteration_time (s ''e'') (s ''f'')
- + elemof_IMP_Minus_loop_time (?s1 ''e'') (?s1 ''f'')"
-        using Suc
-        by simp
-
-      from False b1 have "elemof (s ''e'') (tl_nat (s ''f'')) = elemof (s ''e'') (s ''f'')" by simp
-
-      then have "s(
-          ''a'' := if s ''e'' = hd_nat (s ''f'') then 1 else 0, ''b'' := 0, ''c'' := 0,
-          ''f'' := if s ''e'' = hd_nat (s ''f'') then 0 else tl_nat (s ''f''),
-    ''fst_nat'' := 0, ''snd_nat'' := 0,
-    ''a'' := elemof
-       ((s(''a'' := if s ''e'' = hd_nat (s ''f'') then 1 else 0, ''b'' := 0, ''c'' := 0,
-           ''f'' := if s ''e'' = hd_nat (s ''f'') then 0 else tl_nat (s ''f''), ''fst_nat'' := 0, ''snd_nat'' := 0))
-         ''e'')
-       ((s(''a'' := if s ''e'' = hd_nat (s ''f'') then 1 else 0, ''b'' := 0, ''c'' := 0,
-           ''f'' := if s ''e'' = hd_nat (s ''f'') then 0 else tl_nat (s ''f''), ''fst_nat'' := 0, ''snd_nat'' := 0))
-         ''f''),
-    ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)
-= s(
-    ''a'' := elemof (s ''e'') (s ''f''),
-    ''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0)" using False by simp
-
-
-      then
       show ?thesis unfolding elemof_IMP_Minus_loop_def
-        using
-terminates_in_time_state_intro[OF Big_StepT.WhileTrue[of s], OF b1
-elemof_IMP_Minus_iteration_correct ih iht[symmetric] refl
-] by blast
-
+        apply(rule terminates_in_state_intro[OF Big_StepT.WhileTrue])
+            apply(simp add: Suc)
+           apply(rule elemof_IMP_Minus_iteration_correct)
+          apply(subst elemof_IMP_Minus_loop_def[symmetric])
+          apply(rule 1(1))
+        using False Suc by auto
     qed
   qed
 qed

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -302,4 +302,39 @@ proof(induct "s ''d''" "s ''e''" "s ''f''" arbitrary: s rule: list_from_acc.indu
 qed
 
 
+subsection \<open>concat_acc\<close>
+
+(*
+WHILE n \<noteq> 0
+  acc := append_tail (reverse_nat (hd_nat n)) acc ;
+  n = tl_nat n ;
+
+WHILE n \<noteq> 0
+  $fst = hd_nat n ;             -- $ABC fst
+  $rev = reverse_nat $fst ;     -- $ABCDEF fst snd cons triangle prod_encode
+  $app = append_tail $rev acc ; -- $ABCDEF fst snd cons triangle prod_encode rev app
+  acc := $app ;
+  $snd = tl_nat n ;             -- $ABC snd
+  n = $snd ;
+*)
+
+definition concat_acc_IMP_Minus_iteration where
+  "concat_acc_IMP_Minus_iteration \<equiv>
+  ''a'' ::= ((V ''n'') \<ominus> (N 1)) ;;
+  IMP_Minus_fst_nat ;;
+  ''a'' ::= (A (N 0)) ;;
+  ''b'' ::= (A (V ''fst_nat'')) ;;
+  reverse_nat_acc_IMP_Minus ;;
+  ''e'' ::= (A (V ''reverse_nat_acc'')) ;;
+  ''f'' ::= (A (V ''acc'')) ;;
+  append_tail_IMP_Minus ;;
+  ''acc'' ::= (A (V ''append_tail'')) ;;
+  ''a'' ::= ((V ''n'') \<ominus> (N 1)) ;;
+  IMP_Minus_snd_nat ;;
+  ''n'' ::= (A (V ''snd_nat'')) ;;
+  zero_variables [''a'', ''b'', ''c'', ''d'', ''e'', ''f'',
+    ''fst_nat'', ''snd_nat'', ''cons'', ''triangle'', ''prod_encode'',
+    ''reverse_nat_acc'', ''append_tail'']
+  "
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -278,4 +278,18 @@ elemof_IMP_Minus_iteration_correct ih iht[symmetric] refl
   qed
 qed
 
+
+
+(* Registers:
+  a: e
+  b: l
+*)
+definition elemof_IMP_Minus where "elemof_IMP_Minus \<equiv>
+  ''e'' ::= (A (V ''a'')) ;;
+  ''f'' ::= (A (V ''b'')) ;;
+  zero_variables [''a'', ''b'', ''c'', ''fst_nat'', ''snd_nat''] ;;
+  elemof_IMP_Minus_loop ;;
+  ''elemof'' ::= (A (V ''a'')) ;;
+  zero_variables [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat'']"
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -49,11 +49,6 @@ definition append_tail_IMP_Minus_time where
 + zero_variables_time [''a'', ''b'', ''c'', ''d'', ''e'', ''f'', ''fst_nat'', ''snd_nat'', ''cons'',
     ''triangle'', ''prod_encode'', ''reverse_nat_acc'']"
 
-lemma x: "
-(\<lambda> v . if v = st then 0 else s v)
-= (s(st := 0))
-" by auto
-
 lemma append_tail_IMP_Minus_correct:
   "(append_tail_IMP_Minus, s)
     \<Rightarrow>\<^bsup>append_tail_IMP_Minus_time (s ''e'') (s ''f'')\<^esup>

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -238,4 +238,9 @@ definition list_from_acc_IMP_Minus_iteration where
   ''f'' ::= ((V ''f'') \<ominus> (N 1))
 "
 
+definition list_from_acc_IMP_Minus_iteration_time where
+  "list_from_acc_IMP_Minus_iteration_time h t \<equiv>
+  cons_IMP_Minus_time h t + 6
+"
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -39,13 +39,10 @@ definition append_tail_IMP_Minus where "append_tail_IMP_Minus \<equiv>
 
 definition append_tail_IMP_Minus_time where
   "append_tail_IMP_Minus_time xs ys \<equiv>
-2 + 2 + 2
+16
 + reverse_nat_acc_IMP_Minus_time 0 xs
-+ 2 + 2
 + reverse_nat_acc_IMP_Minus_time (reverse_nat_acc 0 xs) ys
-+ 2 + 2
 + reverse_nat_acc_IMP_Minus_time 0 (reverse_nat_acc (reverse_nat_acc 0 xs) ys)
-+ 2
 + zero_variables_time [''a'', ''b'', ''c'', ''d'', ''e'', ''f'', ''fst_nat'', ''snd_nat'', ''cons'',
     ''triangle'', ''prod_encode'', ''reverse_nat_acc'']"
 

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -337,4 +337,16 @@ definition concat_acc_IMP_Minus_iteration where
     ''reverse_nat_acc'', ''append_tail'']
   "
 
+definition concat_acc_IMP_Minus_iteration_time where
+  "concat_acc_IMP_Minus_iteration_time acc n \<equiv>
+  16
++ IMP_Minus_fst_nat_time (n - 1)
++ reverse_nat_acc_IMP_Minus_time 0 (hd_nat n)
++ append_tail_IMP_Minus_time (reverse_nat_acc 0 (hd_nat n)) acc
++ IMP_Minus_fst_nat_time (n - 1)
++ zero_variables_time [''a'', ''b'', ''c'', ''d'', ''e'', ''f'',
+    ''fst_nat'', ''snd_nat'', ''cons'', ''triangle'', ''prod_encode'',
+    ''reverse_nat_acc'', ''append_tail'']
+"
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -8,7 +8,7 @@ text\<open>Goal of this subsection is *append_tail*, which is defined in terms
   of reverse_nat and append_acc, both of which, in turn, are defined in
   terms of -- or can be related to -- *reverse_nat_acc*.\<close>
 
-lemma "append_acc acc xs = reverse_nat_acc acc xs"
+lemma revapp: "append_acc acc xs = reverse_nat_acc acc xs"
   by(induction xs arbitrary: acc rule: append_acc.induct) simp+
 
 (*

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -267,4 +267,55 @@ fun list_from_acc_IMP_Minus_loop_time where
   1 + list_from_acc_IMP_Minus_iteration_time s acc
   + list_from_acc_IMP_Minus_loop_time (s##acc) (s+1) n"
 
+lemma list_from_acc_loop_correct:
+  assumes "s ''cons'' = s ''d''"
+    "s ''a'' = 0" "s ''b'' = 0" "s ''c'' = 0"
+    "s ''triangle'' = 0" "s ''prod_encode'' = 0" 
+  shows "(WHILE ''f''\<noteq>0 DO list_from_acc_IMP_Minus_iteration, s)
+  \<Rightarrow>\<^bsup>list_from_acc_IMP_Minus_loop_time (s ''d'') (s ''e'') (s ''f'') \<^esup>
+    s(''a'' := 0,
+      ''b'' := 0,
+      ''c'' := 0,
+      ''d'' := list_from_acc (s ''d'') (s ''e'') (s ''f''),
+      ''e'' := (s ''e'') + (s ''f''),
+      ''f'' := 0,
+      ''triangle'' := 0,
+      ''prod_encode'' := 0,
+      ''cons'' := list_from_acc (s ''d'') (s ''e'') (s ''f'')
+    )"
+  using assms
+proof(induct "s ''d''" "s ''e''" "s ''f''" arbitrary: s rule: list_from_acc.induct)
+  case 1
+  show ?case
+  proof(cases "s ''f''")
+    case 0
+    then show ?thesis
+      by(auto simp add: 1 intro!: terminates_in_time_state_intro[OF Big_StepT.WhileFalse])
+  next
+    case (Suc nat)
+    show ?thesis
+      apply(rule terminates_in_state_intro[OF Big_StepT.WhileTrue])
+          apply(simp add: Suc)
+         apply(rule list_from_acc_IMP_Minus_iteration_correct)
+        apply(simp add: 1 Suc)
+        apply(rule 1(1))
+                 apply(simp add: Suc)
+                apply(simp add: 1 Suc)
+               apply(simp add: 1 Suc)
+              apply(simp add: 1 Suc)
+             apply(simp add: 1 Suc)
+            apply(simp add: 1 Suc)
+           apply(simp add: 1 Suc)
+          apply(simp add: 1 Suc)
+         apply(simp add: 1 Suc)
+        apply(simp add: 1 Suc)
+       apply (subst Suc)
+       apply(subst list_from_acc_IMP_Minus_loop_time.simps(2))
+       apply simp
+      apply(simp add: 1 Suc)
+      done
+  qed
+qed
+
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -221,4 +221,6 @@ lemma elemof_IMP_Minus_correct:
       )+
 
 
+subsection \<open>remdups_tail\<close>
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -56,13 +56,11 @@ WHILE 0/=l DO
 *)
 
 definition elemof_IMP_Minus_iteration_time where
-"elemof_IMP_Minus_iteration_time e l \<equiv>
+  "elemof_IMP_Minus_iteration_time e l \<equiv>
   8 + IMP_Minus_fst_nat_time (l - 1) +
   (if e = hd_nat l then 5
-  else
-    5 + IMP_Minus_fst_nat_time (l - 1)
-) +
-  zero_variables_time [''b'', ''c'', ''fst_nat'', ''snd_nat'']"
+  else 5 + IMP_Minus_fst_nat_time (l - 1))
+  + zero_variables_time [''b'', ''c'', ''fst_nat'', ''snd_nat'']"
 
 lemma elemof_IMP_Minus_iteration_correct:
   "(elemof_IMP_Minus_iteration, s)
@@ -107,8 +105,8 @@ fun elemof_IMP_Minus_loop_time :: "nat \<Rightarrow> nat \<Rightarrow> nat" wher
 
 lemma elemof_IMP_Minus_loop_correct:
   assumes "s ''a'' = 0" "s ''b'' = 0" "s ''c'' = 0" "s ''fst_nat'' = 0" "s ''snd_nat'' = 0"
-    shows
-  "(elemof_IMP_Minus_loop, s)
+  shows
+    "(elemof_IMP_Minus_loop, s)
     \<Rightarrow>\<^bsup>elemof_IMP_Minus_loop_time (s ''e'') (s ''f'')\<^esup>
   s(''a'' := elemof (s ''e'') (s ''f''),
     ''b'' := 0,
@@ -116,7 +114,7 @@ lemma elemof_IMP_Minus_loop_correct:
     ''f'' := 0,
     ''fst_nat'' := 0,
     ''snd_nat'' := 0 )"
-using assms
+  using assms
 proof(induction "s ''e''" "s ''f''" arbitrary: s rule: elemof.induct)
   case 1
   then show ?case

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -243,4 +243,22 @@ definition list_from_acc_IMP_Minus_iteration_time where
   cons_IMP_Minus_time h t + 6
 "
 
+lemma list_from_acc_IMP_Minus_iteration_correct:
+  "(list_from_acc_IMP_Minus_iteration, s)
+  \<Rightarrow>\<^bsup>list_from_acc_IMP_Minus_iteration_time (s ''e'') (s ''d'') \<^esup>
+    s(''a'' := 0,
+      ''b'' := 0,
+      ''c'' := 0,
+      ''d'' := (s ''e'')##(s ''d''),
+      ''e'' := (s ''e'') + 1,
+      ''f'' := (s ''f'') - 1,
+      ''triangle'' := 0,
+      ''prod_encode'' := 0,
+      ''cons'' := (s ''e'')##(s ''d'')
+    )"
+  unfolding list_from_acc_IMP_Minus_iteration_def list_from_acc_IMP_Minus_iteration_time_def
+  by(fastforce
+      intro!: terminates_in_time_state_intro[OF Seq']
+      intro: cons_IMP_Minus_correct)+
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -299,4 +299,143 @@ definition elemof_IMP_Minus_time :: "nat \<Rightarrow> nat \<Rightarrow> nat" wh
  + zero_variables_time [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat'']
 "
 
+lemma elemof_IMP_Minus_correct:
+  "(elemof_IMP_Minus, s)
+    \<Rightarrow>\<^bsup>elemof_IMP_Minus_time (s ''a'') (s ''b'')\<^esup>
+  s(''a'' := 0,
+    ''b'' := 0,
+    ''c'' := 0,
+    ''e'' := 0,
+    ''f'' := 0,
+    ''fst_nat'' := 0,
+    ''snd_nat'' := 0,
+    ''elemof'' := elemof (s ''a'') (s ''b'')
+  )"
+  unfolding elemof_IMP_Minus_def elemof_IMP_Minus_time_def
+  apply(rule Seq')+
+       apply (fastforce intro: terminates_in_time_state_intro)
+      apply (fastforce intro: terminates_in_time_state_intro)
+  apply (fastforce intro: zero_variables_correct)
+    apply (fastforce
+        intro: terminates_in_time_state_intro[OF elemof_IMP_Minus_loop_correct]
+        )
+   apply(fastforce intro!: terminates_in_time_state_intro[OF Big_StepT.Assign])
+
+proof-
+
+     have a: "(if s ''b'' = 0 then 0
+        else if hd_nat (s ''b'') = s ''a'' then 1
+             else elemof (s ''a'') (tl_nat (s ''b'')))
+= elemof (s ''a'') (s ''b'')" by simp 
+
+
+     have "(\<lambda>v. if v = ''a'' \<or> v = ''b'' \<or> v = ''c'' \<or> v = ''fst_nat'' \<or> v = ''snd_nat'' then 0 else (s(''e'' := s ''a'', ''f'' := s ''b'')) v)
+=
+ (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
+''e'' := s ''a'', ''f'' := s ''b''))
+" by auto
+     then have "(\<lambda>v. if v = ''a'' \<or> v = ''b'' \<or> v = ''c'' \<or> v = ''fst_nat'' \<or> v = ''snd_nat'' then 0 else (s(''e'' := s ''a'', ''f'' := s ''b'')) v)
+     (''a'' := if s ''b'' = 0 then 0 else if hd_nat (s ''b'') = s ''a'' then 1 else elemof (s ''a'') (tl_nat (s ''b'')), ''b'' := 0, ''c'' := 0,
+      ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
+      ''elemof'' :=
+        if s ''b'' = 0 then 0
+        else if hd_nat (s ''b'') = s ''a'' then 1
+             else elemof (s ''a'') (tl_nat (s ''b'')))
+=
+ (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
+''e'' := s ''a'', ''f'' := s ''b''))
+     (''a'' := if s ''b'' = 0 then 0 else if hd_nat (s ''b'') = s ''a'' then 1 else elemof (s ''a'') (tl_nat (s ''b'')), ''b'' := 0, ''c'' := 0,
+      ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
+      ''elemof'' :=
+        if s ''b'' = 0 then 0
+        else if hd_nat (s ''b'') = s ''a'' then 1
+             else elemof (s ''a'') (tl_nat (s ''b'')))
+" (is "?s1 = _") by simp
+     also have "\<dots> =
+ s(''e'' := s ''a'',
+''a'' := if s ''b'' = 0 then 0 else
+if hd_nat (s ''b'') = s ''a'' then 1 else elemof (s ''a'') (tl_nat (s ''b'')),
+''b'' := 0, ''c'' := 0,
+      ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
+      ''elemof'' :=
+        if s ''b'' = 0 then 0
+        else if hd_nat (s ''b'') = s ''a'' then 1
+             else elemof (s ''a'') (tl_nat (s ''b'')))
+" by simp
+
+
+     also have "\<dots> =
+ s(''e'' := s ''a'',
+''a'' := if s ''b'' = 0 then 0 else
+if hd_nat (s ''b'') = s ''a'' then 1 else elemof (s ''a'') (tl_nat (s ''b'')),
+''b'' := 0, ''c'' := 0,
+      ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
+      ''elemof'' := elemof (s ''a'') (s ''b''))
+" (is "_ = ?s2")
+       using a by simp
+
+     finally have "?s1 = ?s2"
+       by simp
+
+     have "(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] then 0
+      else (?s1) v) =
+(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] then 0
+      else (?s2) v)
+" by auto
+
+     also have "\<dots> =
+(\<lambda>v. (s(''e'' := 0,
+''a'' := 0,
+''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
+''elemof'' := elemof (s ''a'') (s ''b'')))
+                v)
+" by auto
+     also have "\<dots> =
+  (s(''e'' := 0,
+''a'' := 0,
+''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
+''elemof'' := elemof (s ''a'') (s ''b'')))
+" by blast
+
+     ultimately have c1: "(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] then 0
+      else (?s1) v) = 
+s(''e'' := 0, ''a'' := 0, ''b'' := 0, ''c'' := 0,  ''f'' := 0, ''fst_nat'' := 0,
+''snd_nat'' := 0, ''elemof'' := elemof (s ''a'') (s ''b''))"
+       by simp
+
+
+     have "
+s(''e'' := 0, ''a'' := 0, ''b'' := 0, ''c'' := 0,  ''f'' := 0, ''fst_nat'' := 0,
+''snd_nat'' := 0)
+=
+s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''e'' := 0, ''f'' := 0, ''fst_nat'' := 0,
+''snd_nat'' := 0)
+"  by auto
+
+     then have c2: "s(''e'' := 0, ''a'' := 0, ''b'' := 0, ''c'' := 0,  ''f'' := 0, ''fst_nat'' := 0,
+''snd_nat'' := 0, ''elemof'' := elemof (s ''a'') (s ''b''))
+=
+s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''e'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0, ''elemof'' := elemof (s ''a'') (s ''b''))
+" by simp
+
+     from c1 c2 have d: "(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] then 0
+      else (?s1) v) = 
+s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''e'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0, ''elemof'' := elemof (s ''a'') (s ''b''))
+" by simp
+
+
+     show "(zero_variables [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''],
+     ?s1) \<Rightarrow>\<^bsup> zero_variables_time [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] \<^esup> s
+    (''a'' := 0, ''b'' := 0, ''c'' := 0, ''e'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0, ''elemof'' := elemof (s ''a'') (s ''b''))"
+       using  terminates_in_state_intro[OF zero_variables_correct,
+of "[''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat'']"
+?s1 "s
+(''a'' := 0, ''b'' := 0, ''c'' := 0, ''e'' := 0, ''f'' := 0,
+''fst_nat'' := 0, ''snd_nat'' := 0,
+''elemof'' := elemof (s ''a'') (s ''b''))",
+OF d] .
+
+   qed
+
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -37,6 +37,17 @@ definition append_tail_IMP_Minus where "append_tail_IMP_Minus \<equiv>
   zero_variables [''a'', ''b'', ''c'', ''d'', ''e'', ''f'', ''fst_nat'', ''snd_nat'', ''cons'',
     ''triangle'', ''prod_encode'', ''reverse_nat_acc'']"
 
+definition append_tail_IMP_Minus_time where
+  "append_tail_IMP_Minus_time xs ys \<equiv>
+2 + 2 + 2
++ reverse_nat_acc_IMP_Minus_time 0 xs
++ 2 + 2
++ reverse_nat_acc_IMP_Minus_time (reverse_nat_acc 0 xs) ys
++ 2 + 2
++ reverse_nat_acc_IMP_Minus_time 0 (reverse_nat_acc (reverse_nat_acc 0 xs) ys)
++ 2
++ zero_variables_time [''a'', ''b'', ''c'', ''d'', ''e'', ''f'', ''fst_nat'', ''snd_nat'', ''cons'',
+    ''triangle'', ''prod_encode'', ''reverse_nat_acc'']"
 
 
 

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -164,4 +164,8 @@ next
     done
 qed
 
+
+definition elemof_IMP_Minus_loop where "elemof_IMP_Minus_loop \<equiv>
+  (WHILE ''f'' \<noteq>0 DO elemof_IMP_Minus_iteration)"
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -55,4 +55,13 @@ WHILE 0/=l DO
   else l = tl_nat l
 *)
 
+definition elemof_IMP_Minus_iteration_time where
+"elemof_IMP_Minus_iteration_time e l \<equiv>
+  2 + IMP_Minus_fst_nat_time (l - 1) + 2 + 2 + 2 +
+  (if e = hd_nat l then  2 + 2 + 1
+  else
+    2 + IMP_Minus_fst_nat_time (l - 1) + 2 + 1
+) +
+  zero_variables_time [''b'', ''c'', ''fst_nat'', ''snd_nat'']"
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -23,4 +23,36 @@ lemma "append_acc acc xs = reverse_nat_acc acc xs"
 *)
 
 
+
+
+
+subsection \<open>elemof\<close>
+
+(* Registers:
+  e: e
+  f: list
+  a: "result"
+*)
+definition elemof_IMP_Minus_iteration where "elemof_IMP_Minus_iteration \<equiv>
+  ''a'' ::= ((V ''f'') \<ominus> (N 1)) ;;
+  IMP_Minus_fst_nat ;;
+  ''a'' ::= ((V ''fst_nat'') \<ominus> (V ''e'')) ;;
+  ''b'' ::= ((V ''e'') \<ominus> (V ''fst_nat'')) ;;
+  ''a'' ::= ((V ''a'') \<oplus> (V ''b'')) ;;
+  IF ''a''\<noteq>0 THEN
+    ''a'' ::= ((V ''f'') \<ominus> (N 1)) ;;
+    IMP_Minus_snd_nat ;;
+
+    ''f'' ::= (A (V ''snd_nat''))
+  ELSE (
+    ''a'' ::= (A (N 1));;
+    ''f'' ::= (A (N 0))
+  ) ;;
+  zero_variables [''b'', ''c'', ''fst_nat'', ''snd_nat'']"
+(*
+WHILE 0/=l DO
+  if hd_nat l = e then r = 1; BREAK
+  else l = tl_nat l
+*)
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -292,4 +292,11 @@ definition elemof_IMP_Minus where "elemof_IMP_Minus \<equiv>
   ''elemof'' ::= (A (V ''a'')) ;;
   zero_variables [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat'']"
 
+definition elemof_IMP_Minus_time :: "nat \<Rightarrow> nat \<Rightarrow> nat" where
+  "elemof_IMP_Minus_time e l = 2 + 2
+ + zero_variables_time [''a'', ''b'', ''c'', ''fst_nat'', ''snd_nat'']
+ + elemof_IMP_Minus_loop_time e l + 2
+ + zero_variables_time [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat'']
+"
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -18,9 +18,24 @@ lemma "append_acc acc xs = reverse_nat_acc acc xs"
 = reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 xs) ys)
 *)
 
-(*
--- stop -- usage of function --
+(* Registers:
+e: xs
+f: ys
 *)
+definition append_tail_IMP_Minus where "append_tail_IMP_Minus \<equiv>
+  ''a'' ::= (A (N 0)) ;;
+  ''b'' ::= (A (V ''e'')) ;;
+  ''append_tail'' ::= (A (V ''f'')) ;;
+  reverse_nat_acc_IMP_Minus ;;
+  ''a'' ::= (A (V ''reverse_nat_acc'')) ;;
+  ''b'' ::= (A (V ''append_tail'')) ;;
+  reverse_nat_acc_IMP_Minus ;;
+  ''a'' ::= (A (N 0)) ;;
+  ''b'' ::= (A (V ''reverse_nat_acc'')) ;;
+  reverse_nat_acc_IMP_Minus ;;
+  ''append_tail'' ::= (A (V ''reverse_nat_acc'')) ;;
+  zero_variables [''a'', ''b'', ''c'', ''d'', ''e'', ''f'', ''fst_nat'', ''snd_nat'', ''cons'',
+    ''triangle'', ''prod_encode'', ''reverse_nat_acc'']"
 
 
 

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -168,4 +168,9 @@ qed
 definition elemof_IMP_Minus_loop where "elemof_IMP_Minus_loop \<equiv>
   (WHILE ''f'' \<noteq>0 DO elemof_IMP_Minus_iteration)"
 
+fun elemof_IMP_Minus_loop_time :: "nat \<Rightarrow> nat \<Rightarrow> nat" where
+  "elemof_IMP_Minus_loop_time e 0 = 2"
+| "elemof_IMP_Minus_loop_time e l = 1 + elemof_IMP_Minus_iteration_time e l
+ + elemof_IMP_Minus_loop_time e (if e = hd_nat l then 0 else (tl_nat l))"
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -233,92 +233,10 @@ lemma elemof_IMP_Minus_correct:
     ''elemof'' := elemof (s ''a'') (s ''b'')
   )"
   unfolding elemof_IMP_Minus_def elemof_IMP_Minus_time_def
-  apply(rule Seq')+
-       apply (fastforce intro: terminates_in_time_state_intro)
-      apply (fastforce intro: terminates_in_time_state_intro)
-  apply (fastforce intro: zero_variables_correct)
-    apply (fastforce
-        intro: terminates_in_time_state_intro[OF elemof_IMP_Minus_loop_correct]
-        )
-   apply(fastforce intro!: terminates_in_time_state_intro[OF Big_StepT.Assign])
-
-proof-
-  let ?s1 = "(\<lambda>v. if v = ''a'' \<or> v = ''b'' \<or> v = ''c'' \<or> v = ''fst_nat'' \<or> v = ''snd_nat'' then 0 else (s(''e'' := s ''a'', ''f'' := s ''b'')) v)
-     (''a'' := if s ''b'' = 0 then 0 else if hd_nat (s ''b'') = s ''a'' then 1 else elemof (s ''a'') (tl_nat (s ''b'')), ''b'' := 0, ''c'' := 0,
-      ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
-      ''elemof'' :=
-        if s ''b'' = 0 then 0
-        else if hd_nat (s ''b'') = s ''a'' then 1
-             else elemof (s ''a'') (tl_nat (s ''b'')))"
-
-     let ?s2 = "
- s(''e'' := s ''a'',
-''a'' := if s ''b'' = 0 then 0 else
-if hd_nat (s ''b'') = s ''a'' then 1 else elemof (s ''a'') (tl_nat (s ''b'')),
-''b'' := 0, ''c'' := 0,
-      ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
-      ''elemof'' := elemof (s ''a'') (s ''b''))
-"
-
-     have "(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] then 0
-      else (?s1) v) =
-(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] then 0
-      else (?s2) v)
-" by auto
-
-     also have "\<dots> =
-(\<lambda>v. (s(''e'' := 0,
-''a'' := 0,
-''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
-''elemof'' := elemof (s ''a'') (s ''b'')))
-                v)
-" by auto
-     also have "\<dots> =
-  (s(''e'' := 0,
-''a'' := 0,
-''b'' := 0, ''c'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
-''elemof'' := elemof (s ''a'') (s ''b'')))
-" by blast
-
-     ultimately have c1: "(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] then 0
-      else (?s1) v) = 
-s(''e'' := 0, ''a'' := 0, ''b'' := 0, ''c'' := 0,  ''f'' := 0, ''fst_nat'' := 0,
-''snd_nat'' := 0, ''elemof'' := elemof (s ''a'') (s ''b''))"
-       by simp
-
-
-     have "
-s(''e'' := 0, ''a'' := 0, ''b'' := 0, ''c'' := 0,  ''f'' := 0, ''fst_nat'' := 0,
-''snd_nat'' := 0)
-=
-s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''e'' := 0, ''f'' := 0, ''fst_nat'' := 0,
-''snd_nat'' := 0)
-"  by auto
-
-     then have c2: "s(''e'' := 0, ''a'' := 0, ''b'' := 0, ''c'' := 0,  ''f'' := 0, ''fst_nat'' := 0,
-''snd_nat'' := 0, ''elemof'' := elemof (s ''a'') (s ''b''))
-=
-s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''e'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0, ''elemof'' := elemof (s ''a'') (s ''b''))
-" by simp
-
-     from c1 c2 have d: "(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] then 0
-      else (?s1) v) = 
-s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''e'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0, ''elemof'' := elemof (s ''a'') (s ''b''))
-" by simp
-
-
-     show "(zero_variables [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''],
-     ?s1) \<Rightarrow>\<^bsup> zero_variables_time [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] \<^esup> s
-    (''a'' := 0, ''b'' := 0, ''c'' := 0, ''e'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0, ''elemof'' := elemof (s ''a'') (s ''b''))"
-       using  terminates_in_state_intro[OF zero_variables_correct,
-of "[''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat'']"
-?s1 "s
-(''a'' := 0, ''b'' := 0, ''c'' := 0, ''e'' := 0, ''f'' := 0,
-''fst_nat'' := 0, ''snd_nat'' := 0,
-''elemof'' := elemof (s ''a'') (s ''b''))",
-OF d] .
-
-   qed
+  by(fastforce
+      intro!: ext terminates_in_time_state_intro[OF Seq']
+      intro: zero_variables_correct elemof_IMP_Minus_loop_correct
+      )+
 
 
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -368,4 +368,11 @@ lemma concat_acc_IMP_Minus_iteration_correct:
       append_tail_IMP_Minus_correct
       zero_variables_correct)+
 
+fun concat_acc_IMP_Minus_loop_time where
+  "concat_acc_IMP_Minus_loop_time acc 0 = 2"
+| "concat_acc_IMP_Minus_loop_time acc n = 1
++ concat_acc_IMP_Minus_iteration_time acc n
++ concat_acc_IMP_Minus_loop_time (append_tail (reverse_nat (hd_nat n)) acc) (tl_nat n)
+"
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -349,4 +349,23 @@ definition concat_acc_IMP_Minus_iteration_time where
     ''reverse_nat_acc'', ''append_tail'']
 "
 
+lemma concat_acc_IMP_Minus_iteration_correct:
+  "(concat_acc_IMP_Minus_iteration, s)
+    \<Rightarrow>\<^bsup>concat_acc_IMP_Minus_iteration_time (s ''acc'') (s ''n'')\<^esup>
+  s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0,
+  ''fst_nat'' := 0, ''snd_nat'' := 0, ''cons'' := 0,
+  ''triangle'' := 0, ''prod_encode'' := 0,
+  ''reverse_nat_acc'' := 0, ''append_tail'' := 0,
+  ''acc'' := append_tail (reverse_nat (hd_nat (s ''n''))) (s ''acc''),
+  ''n'' := tl_nat (s ''n'')
+)"
+  unfolding concat_acc_IMP_Minus_iteration_def
+    concat_acc_IMP_Minus_iteration_time_def
+  by(fastforce simp: hd_nat_def tl_nat_def reverse_nat_def
+      intro!: ext terminates_in_time_state_intro[OF Seq']
+      intro: IMP_Minus_fst_nat_correct IMP_Minus_snd_nat_correct
+      reverse_nat_acc_IMP_Minus_correct
+      append_tail_IMP_Minus_correct
+      zero_variables_correct)+
+
 end

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -62,80 +62,11 @@ lemma append_tail_IMP_Minus_correct:
     ''triangle'':=0, ''prod_encode'':=0, ''reverse_nat_acc'':=0,
     ''append_tail'':= append_tail (s ''e'') (s ''f''))"
   unfolding append_tail_IMP_Minus_def append_tail_IMP_Minus_time_def
-  apply(rule Seq')+
-             apply(simp add: numeral_2_eq_2)
-             apply(rule terminates_in_state_intro[OF Big_StepT.Assign])
-             apply (rule refl)
-            apply(simp add: numeral_2_eq_2)
-            apply(rule terminates_in_state_intro[OF Big_StepT.Assign])
-            apply simp
-           apply(simp add: numeral_2_eq_2)
-           apply(rule terminates_in_state_intro[OF Big_StepT.Assign])
-           apply simp
-          apply(rule terminates_in_time_state_intro[OF reverse_nat_acc_IMP_Minus_correct])
-           apply simp apply (simp del: reverse_nat_acc.simps)
-         apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
-          apply simp apply (simp del: reverse_nat_acc.simps)
-        apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
-         apply simp apply (simp del: reverse_nat_acc.simps)
-       apply(rule terminates_in_time_state_intro[OF reverse_nat_acc_IMP_Minus_correct])
-
-        apply (simp) apply (simp del: reverse_nat_acc.simps)
-      apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
-       apply simp apply (simp del: reverse_nat_acc.simps)
-     apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
-      apply simp apply (simp del: reverse_nat_acc.simps)
-    apply(rule terminates_in_time_state_intro[OF reverse_nat_acc_IMP_Minus_correct])
-     apply simp apply (simp del: reverse_nat_acc.simps)
-   apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
-    apply simp apply (simp del: reverse_nat_acc.simps)
-  apply(rule terminates_in_state_intro[OF zero_variables_correct])
-  apply (subst append_tail_def)
-  apply(subst revapp)
-  apply(subst reverse_nat_def)
-  apply(subst reverse_nat_def)
-  using x fun_upd_twist
-proof -
-  have " (\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''d'', ''e'', ''f'', ''fst_nat'', ''snd_nat'', ''cons'', ''triangle'', ''prod_encode'', ''reverse_nat_acc''] then 0
-          else (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0, ''triangle'' := 0, ''prod_encode'' := 0, ''cons'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
-                  ''reverse_nat_acc'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f'')),
-                  ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f''))))
-                v)
-=
-(\<lambda>v. if v = ''reverse_nat_acc'' then 0
-          else (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0,
- ''fst_nat'' := 0, ''snd_nat'' := 0, ''cons'' := 0, ''triangle'' := 0, ''prod_encode'' := 0,
-  ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f''))
-))
-v)
-" by auto
-
-  also have "\<dots> =
-  (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0,
- ''fst_nat'' := 0, ''snd_nat'' := 0, ''cons'' := 0, ''triangle'' := 0, ''prod_encode'' := 0,
-  ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f'')),
-''reverse_nat_acc'' := 0
-))
-" using x[of "''reverse_nat_acc''" ]  .
-
-  also have "\<dots> =
-  (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0,
- ''fst_nat'' := 0, ''snd_nat'' := 0, ''cons'' := 0, ''triangle'' := 0, ''prod_encode'' := 0,
-''reverse_nat_acc'' := 0,
-  ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f''))
-))
-" by (simp add: fun_upd_twist)
-
-
-  finally show "(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''d'', ''e'', ''f'', ''fst_nat'', ''snd_nat'', ''cons'', ''triangle'', ''prod_encode'', ''reverse_nat_acc''] then 0
-          else (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0, ''triangle'' := 0, ''prod_encode'' := 0, ''cons'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
-                  ''reverse_nat_acc'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f'')),
-                  ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f''))))
-                v) =
-    s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''d'' := 0, ''e'' := 0, ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0, ''cons'' := 0, ''triangle'' := 0, ''prod_encode'' := 0,
-      ''reverse_nat_acc'' := 0, ''append_tail'' := reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 (s ''e'')) (s ''f'')))"
-    by simp
-qed
+  by (fastforce simp: ext reverse_nat_def revapp append_tail_def
+      simp del: reverse_nat_acc.simps
+      intro!: terminates_in_time_state_intro[OF Seq']
+      intro: zero_variables_correct reverse_nat_acc_IMP_Minus_correct
+      )+
 
 
 subsection \<open>elemof\<close>

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -322,60 +322,22 @@ lemma elemof_IMP_Minus_correct:
    apply(fastforce intro!: terminates_in_time_state_intro[OF Big_StepT.Assign])
 
 proof-
-
-     have a: "(if s ''b'' = 0 then 0
-        else if hd_nat (s ''b'') = s ''a'' then 1
-             else elemof (s ''a'') (tl_nat (s ''b'')))
-= elemof (s ''a'') (s ''b'')" by simp 
-
-
-     have "(\<lambda>v. if v = ''a'' \<or> v = ''b'' \<or> v = ''c'' \<or> v = ''fst_nat'' \<or> v = ''snd_nat'' then 0 else (s(''e'' := s ''a'', ''f'' := s ''b'')) v)
-=
- (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
-''e'' := s ''a'', ''f'' := s ''b''))
-" by auto
-     then have "(\<lambda>v. if v = ''a'' \<or> v = ''b'' \<or> v = ''c'' \<or> v = ''fst_nat'' \<or> v = ''snd_nat'' then 0 else (s(''e'' := s ''a'', ''f'' := s ''b'')) v)
+  let ?s1 = "(\<lambda>v. if v = ''a'' \<or> v = ''b'' \<or> v = ''c'' \<or> v = ''fst_nat'' \<or> v = ''snd_nat'' then 0 else (s(''e'' := s ''a'', ''f'' := s ''b'')) v)
      (''a'' := if s ''b'' = 0 then 0 else if hd_nat (s ''b'') = s ''a'' then 1 else elemof (s ''a'') (tl_nat (s ''b'')), ''b'' := 0, ''c'' := 0,
       ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
       ''elemof'' :=
         if s ''b'' = 0 then 0
         else if hd_nat (s ''b'') = s ''a'' then 1
-             else elemof (s ''a'') (tl_nat (s ''b'')))
-=
- (s(''a'' := 0, ''b'' := 0, ''c'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
-''e'' := s ''a'', ''f'' := s ''b''))
-     (''a'' := if s ''b'' = 0 then 0 else if hd_nat (s ''b'') = s ''a'' then 1 else elemof (s ''a'') (tl_nat (s ''b'')), ''b'' := 0, ''c'' := 0,
-      ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
-      ''elemof'' :=
-        if s ''b'' = 0 then 0
-        else if hd_nat (s ''b'') = s ''a'' then 1
-             else elemof (s ''a'') (tl_nat (s ''b'')))
-" (is "?s1 = _") by simp
-     also have "\<dots> =
- s(''e'' := s ''a'',
-''a'' := if s ''b'' = 0 then 0 else
-if hd_nat (s ''b'') = s ''a'' then 1 else elemof (s ''a'') (tl_nat (s ''b'')),
-''b'' := 0, ''c'' := 0,
-      ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
-      ''elemof'' :=
-        if s ''b'' = 0 then 0
-        else if hd_nat (s ''b'') = s ''a'' then 1
-             else elemof (s ''a'') (tl_nat (s ''b'')))
-" by simp
+             else elemof (s ''a'') (tl_nat (s ''b'')))"
 
-
-     also have "\<dots> =
+     let ?s2 = "
  s(''e'' := s ''a'',
 ''a'' := if s ''b'' = 0 then 0 else
 if hd_nat (s ''b'') = s ''a'' then 1 else elemof (s ''a'') (tl_nat (s ''b'')),
 ''b'' := 0, ''c'' := 0,
       ''f'' := 0, ''fst_nat'' := 0, ''snd_nat'' := 0,
       ''elemof'' := elemof (s ''a'') (s ''b''))
-" (is "_ = ?s2")
-       using a by simp
-
-     finally have "?s1 = ?s2"
-       by simp
+"
 
      have "(\<lambda>v. if v \<in> set [''a'', ''b'', ''c'', ''e'', ''f'', ''fst_nat'', ''snd_nat''] then 0
       else (?s1) v) =

--- a/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
+++ b/Cook_Levin/IMP-_To_SAS+/IMP_Minus_Common_Funs_Nat.thy
@@ -2,4 +2,25 @@ theory IMP_Minus_Common_Funs_Nat
   imports "../../IMP-/IMP_Minus_Nat_Bijection"
 begin
 
+subsection \<open>append\<close>
+
+text\<open>Goal of this subsection is *append_tail*, which is defined in terms
+  of reverse_nat and append_acc, both of which, in turn, are defined in
+  terms of -- or can be related to -- *reverse_nat_acc*.\<close>
+
+lemma "append_acc acc xs = reverse_nat_acc acc xs"
+  by(induction xs arbitrary: acc rule: append_acc.induct) simp+
+
+(*
+  append_tail xs ys
+= reverse_nat       (append_acc      (reverse_nat       xs) ys)
+= reverse_nat       (reverse_nat_acc (reverse_nat       xs) ys)
+= reverse_nat_acc 0 (reverse_nat_acc (reverse_nat_acc 0 xs) ys)
+*)
+
+(*
+-- stop -- usage of function --
+*)
+
+
 end

--- a/IMP-/IMP_Minus_Nat_Bijection.thy
+++ b/IMP-/IMP_Minus_Nat_Bijection.thy
@@ -310,8 +310,8 @@ fun cons_list_IMP_Minus_state_transformer where
 "
 
 lemma cons_list_IMP_Minus_correct[intro]:
-assumes "distinct vs"
-shows
+  assumes "distinct vs"
+  shows
     "(cons_list_IMP_Minus vs p, s) 
       \<Rightarrow>\<^bsup>cons_list_IMP_Minus_time (map (\<lambda>i. s (add_prefix (''a'' @ p) i)) vs)\<^esup>
       cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (add_prefix (''a'' @ p) i)) vs) vs s"
@@ -348,9 +348,6 @@ proof(induction vs arbitrary: s)
     define s7 where "s7 =
       s6(add_prefix (''a'' @ p) v := aval (aexp_add_prefix p (A (N 0))) s6)"
 
-(*
-    have "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s (arg b) = (s (arg b))" sorry
-*)
     have "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) vs) vs s (arg v) = s (arg v)"
       using ConsV(2)
     proof(induct vs)
@@ -526,29 +523,11 @@ proof(induction vs arbitrary: s)
      in s7 (add_prefix p ''cons_list''))
      " by metis
           also have "\<dots> =
-(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s
-     in (s1 (add_prefix (''a'' @ p) b))
-              ##  (s1 (add_prefix p ''cons_list''))
+(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s
+     in  (cons_list (map (\<lambda>i. s (arg i)) (b'#bs') ))
 )
-" by simp
-          also have "\<dots> =
-(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s
-     in (s (arg b))
-              ##  (cons_list (map (\<lambda>i. s (arg i)) bs))
-)
-" using ih arg_def c2_0 by simp
+" using Cons ih arg_def c2_0 by simp
 
-          also have "\<dots> =
-(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s
-     in  (cons_list ((s (arg b)) # map (\<lambda>i. s (arg i)) bs))
-)
-" using Cons by simp
-
-          also have "\<dots> =
-(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s
-     in  (cons_list (map (\<lambda>i. s (arg i)) (b#bs) ))
-)
-" using Cons by simp
           finally show "(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s; s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b))) s1);
          s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
          s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
@@ -591,14 +570,10 @@ proof(induction vs arbitrary: s)
            apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
             apply simp  apply(rule refl)
           apply(subst s2_def[symmetric])
-
           apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
            apply simp apply (rule refl)
          apply(subst s3_def[symmetric])
-
          apply(rule terminates_in_time_state_intro[OF cons_IMP_Minus_correct])
-          apply simp
-
           apply(subst c1[symmetric]) apply(subst c2[symmetric]) apply simp
          apply(rule refl)
         apply(subst s4_def[symmetric])

--- a/IMP-/IMP_Minus_Nat_Bijection.thy
+++ b/IMP-/IMP_Minus_Nat_Bijection.thy
@@ -309,6 +309,75 @@ fun cons_list_IMP_Minus_state_transformer where
   )
 "
 
+lemma aux:
+  assumes arg_def: "ar = add_prefix (''a'' @ p)"
+  assumes dist: "distinct (v#vs)"
+  shows "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (ar i)) vs) vs s (ar v) = s (ar v)"
+  using dist
+proof(induct vs)
+  case Nil
+  then show ?case by simp
+next
+  case (Cons b' bs')
+  then have x1: "v \<noteq> b'" by simp
+  have ih: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (ar i)) bs') bs' s (ar v) = s (ar v)"
+    using Cons by simp
+  show ?case
+    apply(subst List.list.map(2))
+    apply(subst cons_list_IMP_Minus_state_transformer.simps(2))
+    apply(cases bs')
+    subgoal
+      apply(auto simp: arg_def x1)
+      done
+  proof -
+    fix c cs
+    assume ConsC: "bs' = c#cs"
+    then have "(if map (\<lambda>i. s (ar i)) bs' = [] then state_transformer (''a'' @ p) [(b', 0)] \<circ> state_transformer p [(''cons_list'', s (ar b'))]
+        else (\<lambda>s0. let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (ar i)) bs') bs' s0;
+                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
+                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
+                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
+                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
+                        s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
+                    in s7))
+        s (ar v) =
+(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (ar i)) bs') bs' s;
+                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
+                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
+                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
+                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
+                    in s7) (ar v)
+" by simp
+    also have "\<dots> =
+(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (ar i)) bs') bs' s;
+                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
+                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
+                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
+                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
+                        s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
+                    in s7 (ar v))
+" 
+      by metis
+    also have "\<dots> = s (ar v)" using ih  by (auto simp: arg_def x1)
+
+    finally show "(if map (\<lambda>i. s (ar i)) bs' = [] then state_transformer (''a'' @ p) [(b', 0)] \<circ> state_transformer p [(''cons_list'', s (ar b'))]
+        else (\<lambda>s0. let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (ar i)) bs') bs' s0;
+                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
+                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
+                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
+                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
+                        s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
+                    in s7))
+        s (ar v) =
+       s (ar v)" by simp
+  qed
+qed
+
+
 lemma cons_list_IMP_Minus_correct[intro]:
   assumes "distinct vs"
   shows
@@ -352,67 +421,7 @@ proof(induction vs arbitrary: s)
       s6(add_prefix (''a'' @ p) v := aval (aexp_add_prefix p (A (N 0))) s6)"
 
     have "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) vs) vs s (arg v) = s (arg v)"
-      using ConsV(2)
-    proof(induct vs)
-      case Nil
-      then show ?case by simp
-    next
-      case (Cons b' bs')
-      then have x1: "v \<noteq> b'" by simp
-      have ih: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s (arg v) = s (arg v)"
-        using Cons by simp
-      show ?case
-        apply(subst List.list.map(2))
-        apply(subst cons_list_IMP_Minus_state_transformer.simps(2))
-        apply(cases bs')
-        subgoal
-          apply(auto simp: arg_def x1)
-          done
-      proof -
-        fix c cs
-        assume ConsC: "bs' = c#cs"
-        then have "(if map (\<lambda>i. s (arg i)) bs' = [] then state_transformer (''a'' @ p) [(b', 0)] \<circ> state_transformer p [(''cons_list'', s (arg b'))]
-        else (\<lambda>s0. let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s0;
-                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
-                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
-                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
-                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
-                    in s7))
-        s (arg v) =
-(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s;
-                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
-                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
-                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
-                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
-                    in s7) (arg v)
-" by simp
-        also have "\<dots> =
-(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s;
-                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
-                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
-                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
-                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
-                        s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
-                    in s7 (arg v))
-" 
-          by metis
-        also have "\<dots> = s (arg v)" using ih  by (auto simp: arg_def x1)
-
-        finally show "(if map (\<lambda>i. s (arg i)) bs' = [] then state_transformer (''a'' @ p) [(b', 0)] \<circ> state_transformer p [(''cons_list'', s (arg b'))]
-        else (\<lambda>s0. let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s0;
-                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
-                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
-                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
-                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
-                    in s7))
-        s (arg v) =
-       s (arg v)" by simp
-      qed
-    qed
+      using aux arg_def ConsV(2) by simp
 
     then have c1: "(s3 (add_prefix (''b'' @ p) ''a'')) = (s (arg v))"
       by (auto simp: s3_def s2_def s1_def arg_def)
@@ -448,69 +457,10 @@ proof(induction vs arbitrary: s)
           apply(subst List.list.simps(3))
           apply(subst HOL.if_False)
         proof -
-          (*same as vs version*)
           have "distinct (b' # bs')" using 2(3) by simp
           then have c2_0: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s (arg b')
       = s (arg b')"
-          proof(induct bs')
-            case Nil
-            then show ?case by simp
-          next
-            case (Cons c' cs')
-            then have x1: "b' \<noteq> c'" by simp
-            have ih: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) cs') cs' s (arg b') = s (arg b')"
-              using Cons by simp
-            show ?case
-              apply(subst List.list.map(2))
-              apply(subst cons_list_IMP_Minus_state_transformer.simps(2))
-              apply(cases cs')
-              subgoal
-                apply(auto simp: arg_def x1)
-                done
-            proof -
-              fix d ds
-              assume ConsC: "cs' = d#ds"
-              then have "(if map (\<lambda>i. s (arg i)) cs' = [] then state_transformer (''a'' @ p) [(c', 0)] \<circ> state_transformer p [(''cons_list'', s (arg c'))]
-        else (\<lambda>s0. let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) cs') cs' s0;
-                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V c'))) s1);
-                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
-                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
-                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) c' := aval (aexp_add_prefix p (A (N 0))) s6)
-                    in s7))
-        s (arg b') =
-(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) cs') cs' s;
-                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V c'))) s1);
-                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
-                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
-                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) c' := aval (aexp_add_prefix p (A (N 0))) s6)
-                    in s7) (arg b')
-" by simp
-              also have "\<dots> =
-(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) cs') cs' s;
-                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V c'))) s1);
-                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
-                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
-                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) c' := aval (aexp_add_prefix p (A (N 0))) s6)
-                    in s7 (arg b'))
-" 
-                by metis
-              also have "\<dots> = s (arg b')" using ih by (auto simp: arg_def x1)
-
-              finally show "(if map (\<lambda>i. s (arg i)) cs' = [] then state_transformer (''a'' @ p) [(c', 0)] \<circ> state_transformer p [(''cons_list'', s (arg c'))]
-        else (\<lambda>s0. let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) cs') cs' s0;
-                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V c'))) s1);
-                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
-                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
-                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) c' := aval (aexp_add_prefix p (A (N 0))) s6)
-                    in s7))
-        s (arg b') =
-       s (arg b')" by simp
-            qed
-          qed
+            using aux arg_def ConsV(2) by simp
 
           have "(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s;
          s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);

--- a/IMP-/IMP_Minus_Nat_Bijection.thy
+++ b/IMP-/IMP_Minus_Nat_Bijection.thy
@@ -423,18 +423,19 @@ proof(induction vs arbitrary: s)
       cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) vs) vs
           s (add_prefix p ''cons_list'') =
  (cons_list (map (\<lambda>i. s (arg i)) vs))"
+      using ConsV(2)
     proof(induct vs rule: cons_list_IMP_Minus.induct)
       case 1
       then show ?case by simp
     next
-      case (2 b bs)
+      case (2 b' bs')
       then show ?case
-      proof(cases bs)
+      proof(cases bs')
         case Nil
         then show ?thesis by auto
       next
         case (Cons c cs)
-        then have ih: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s (add_prefix p ''cons_list'') = cons_list (map (\<lambda>i. s (arg i)) bs)"
+        then have ih: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s (add_prefix p ''cons_list'') = cons_list (map (\<lambda>i. s (arg i)) bs')"
           using 2 by simp
         show ?thesis
           apply(subst List.list.map(2))
@@ -445,16 +446,16 @@ proof(induction vs arbitrary: s)
           apply(subst HOL.if_False)
         proof -
           (*same as vs version*)
-          have "distinct (b # bs)" using ConsV(2) ConsB by simp
-          then have c2_0: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s (arg b)
-      = s (arg b)"
-          proof(induct bs)
+          have "distinct (b' # bs')" using 2(3) by simp
+          then have c2_0: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s (arg b')
+      = s (arg b')"
+          proof(induct bs')
             case Nil
             then show ?case by simp
           next
             case (Cons c' cs')
-            then have x1: "b \<noteq> c'" by simp
-            have ih: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) cs') cs' s (arg b) = s (arg b)"
+            then have x1: "b' \<noteq> c'" by simp
+            have ih: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) cs') cs' s (arg b') = s (arg b')"
               using Cons by simp
             show ?case
               apply(subst List.list.map(2))
@@ -474,14 +475,14 @@ proof(induction vs arbitrary: s)
                         s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
                         s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) c' := aval (aexp_add_prefix p (A (N 0))) s6)
                     in s7))
-        s (arg b) =
+        s (arg b') =
 (let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) cs') cs' s;
                         s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V c'))) s1);
                         s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
                         s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
                         s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
                         s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) c' := aval (aexp_add_prefix p (A (N 0))) s6)
-                    in s7) (arg b)
+                    in s7) (arg b')
 " by simp
               also have "\<dots> =
 (let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) cs') cs' s;
@@ -490,10 +491,10 @@ proof(induction vs arbitrary: s)
                         s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
                         s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
                         s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) c' := aval (aexp_add_prefix p (A (N 0))) s6)
-                    in s7 (arg b))
+                    in s7 (arg b'))
 " 
                 by metis
-              also have "\<dots> = s (arg b)" using ih by (auto simp: arg_def x1)
+              also have "\<dots> = s (arg b')" using ih by (auto simp: arg_def x1)
 
               finally show "(if map (\<lambda>i. s (arg i)) cs' = [] then state_transformer (''a'' @ p) [(c', 0)] \<circ> state_transformer p [(''cons_list'', s (arg c'))]
         else (\<lambda>s0. let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) cs') cs' s0;
@@ -503,23 +504,27 @@ proof(induction vs arbitrary: s)
                         s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
                         s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) c' := aval (aexp_add_prefix p (A (N 0))) s6)
                     in s7))
-        s (arg b) =
-       s (arg b)" by simp
+        s (arg b') =
+       s (arg b')" by simp
             qed
           qed
 
-          have "(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s; s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b))) s1);
+          have "(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s;
+         s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
          s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
          s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-         s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4); s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
-         s7 = s6(add_prefix (''a'' @ p) b := aval (aexp_add_prefix p (A (N 0))) s6)
+         s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+          s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
+         s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
      in s7)
      (add_prefix p ''cons_list'') =
-(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s; s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b))) s1);
+(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s;
+         s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
          s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
          s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-         s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4); s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
-         s7 = s6(add_prefix (''a'' @ p) b := aval (aexp_add_prefix p (A (N 0))) s6)
+         s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+         s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
+         s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
      in s7 (add_prefix p ''cons_list''))
      " by metis
           also have "\<dots> =
@@ -528,14 +533,16 @@ proof(induction vs arbitrary: s)
 )
 " using Cons ih arg_def c2_0 by simp
 
-          finally show "(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs) bs s; s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b))) s1);
+          finally show "(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s;
+         s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
          s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
          s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
-         s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4); s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
-         s7 = s6(add_prefix (''a'' @ p) b := aval (aexp_add_prefix p (A (N 0))) s6)
+         s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+         s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
+         s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
      in s7)
      (add_prefix p ''cons_list'') =
-    cons_list (map (\<lambda>i. s (arg i)) (b # bs))" by simp
+    cons_list (map (\<lambda>i. s (arg i)) (b' # bs'))" by simp
 
         qed
       qed

--- a/IMP-/IMP_Minus_Nat_Bijection.thy
+++ b/IMP-/IMP_Minus_Nat_Bijection.thy
@@ -330,6 +330,7 @@ proof(induction vs arbitrary: s)
     have "b \<noteq> v" using ConsB ConsV by auto
 
     have d: "distinct vs" using ConsV by simp
+
     define s1 where "s1 =
       cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) vs) vs s"
     define s2 where "s2 =
@@ -347,11 +348,10 @@ proof(induction vs arbitrary: s)
     define s7 where "s7 =
       s6(add_prefix (''a'' @ p) v := aval (aexp_add_prefix p (A (N 0))) s6)"
 
-    have c0: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) vs) vs s (arg v)
-      = s (arg v)" sorry
     have c1: "(s3 (add_prefix (''b'' @ p) ''a'')) = (s (arg v))"
         sorry
-    have c2: "(s3 (add_prefix (''b'' @ p) ''b'')) = (cons_list (map (\<lambda>i. s (arg i)) vs))" sorry
+      have c2: "(s3 (add_prefix (''b'' @ p) ''b'')) = (cons_list (map (\<lambda>i. s (arg i)) vs))"
+        sorry
 
     show ?thesis
       apply(subst arg_def[symmetric])+
@@ -379,11 +379,14 @@ proof(induction vs arbitrary: s)
            apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
             apply simp  apply(rule refl)
           apply(subst s2_def[symmetric])
+
           apply(rule terminates_in_time_state_intro[OF Big_StepT.Assign])
            apply simp apply (rule refl)
          apply(subst s3_def[symmetric])
+
          apply(rule terminates_in_time_state_intro[OF cons_IMP_Minus_correct])
           apply simp
+
           apply(subst c1[symmetric]) apply(subst c2[symmetric]) apply simp
          apply(rule refl)
         apply(subst s4_def[symmetric])
@@ -409,53 +412,10 @@ proof(induction vs arbitrary: s)
       apply(subst Let_def)+
       apply(simp add: s7_def s6_def s5_def s4_def s3_def s2_def s1_def)
       done
-
-fun cons_list_IMP_Minus_state_transformer where 
-  "cons_list_IMP_Minus_state_transformer p [] vs = (\<lambda>s. s)" |
-  "cons_list_IMP_Minus_state_transformer p (a # as) vs = (if as = [] then
-    state_transformer p [(''cons_list'', a)]
-    else
-      state_transformer p [(''cons_list'', cons_list (a # as))]
-      \<circ> cons_IMP_Minus_state_transformer (''b'' @ p) 0 0
-    )
-    \<circ> state_transformer (''a'' @ p) (map (\<lambda>v. (v, 0)) vs)"
-
-lemma cons_list_IMP_Minus_correct[intro]:
-    "(cons_list_IMP_Minus vs p, s) 
-      \<Rightarrow>\<^bsup>cons_list_IMP_Minus_time (map (\<lambda>i. s (add_prefix (''a'' @ p) i)) vs)\<^esup>
-      cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (add_prefix (''a'' @ p) i)) vs) vs s"
-proof(induction vs arbitrary: s)
-  case (Cons v vs)
-  then show ?case
-  proof (cases vs)
-    case Nil
-    then show ?thesis
-      by (auto 
-          simp: state_transformer_commutes'
-          intro!: terminates_in_time_state_intro[OF Seq'])
-  next
-    case (Cons b bs)
-    thus ?thesis
-      apply auto
-      subgoal
-        apply(rule terminates_in_time_state_intro[OF Seq'])
-        apply(rule Seq')+
-                 apply fastforce+
-        using Cons local.Cons
-      apply(auto)
-      using state_transformer_same_prefix_equal_commutes 
-      using local.Cons apply fastforce
-      apply(rule cons_IMP_Minus_correct)
-      by(fastforce intro!: Cons.IH[OF _ *] cons_IMP_Minus_correct)+
   qed
-qed auto
+qed simp
 
-declare cons_list_IMP_Minus.simps [simp del]
-declare cons_list_IMP_Minus_time.simps [simp del]
 
-(*"reverse_nat_acc acc e  n f =
-  (if n = 0 then acc 
-   else reverse_nat_acc ((hd_nat n) ## acc) (tl_nat n) )"*)
 
 definition reverse_nat_acc_IMP_Minus_iteration where "reverse_nat_acc_IMP_Minus_iteration \<equiv>
   ''a'' ::= ((V ''f'') \<ominus> (N 1)) ;;

--- a/IMP-/IMP_Minus_Nat_Bijection.thy
+++ b/IMP-/IMP_Minus_Nat_Bijection.thy
@@ -348,10 +348,73 @@ proof(induction vs arbitrary: s)
     define s7 where "s7 =
       s6(add_prefix (''a'' @ p) v := aval (aexp_add_prefix p (A (N 0))) s6)"
 
-    have c1: "(s3 (add_prefix (''b'' @ p) ''a'')) = (s (arg v))"
-        sorry
       have c2: "(s3 (add_prefix (''b'' @ p) ''b'')) = (cons_list (map (\<lambda>i. s (arg i)) vs))"
         sorry
+    have "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) vs) vs s (arg v) = s (arg v)"
+      using ConsV(2)
+    proof(induct vs)
+      case Nil
+      then show ?case by simp
+    next
+      case (Cons b' bs')
+      then have x1: "v \<noteq> b'" by simp
+      have ih: "cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s (arg v) = s (arg v)"
+        using Cons by simp
+      show ?case
+        apply(subst List.list.map(2))
+        apply(subst cons_list_IMP_Minus_state_transformer.simps(2))
+        apply(cases bs')
+        subgoal
+          apply(auto simp: arg_def x1)
+          done
+      proof -
+        fix c cs
+        assume ConsC: "bs' = c#cs"
+        then have "(if map (\<lambda>i. s (arg i)) bs' = [] then state_transformer (''a'' @ p) [(b', 0)] \<circ> state_transformer p [(''cons_list'', s (arg b'))]
+        else (\<lambda>s0. let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s0;
+                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
+                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
+                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
+                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
+                    in s7))
+        s (arg v) =
+(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s;
+                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
+                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
+                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
+                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
+                    in s7) (arg v)
+" by simp
+        also have "\<dots> =
+(let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s;
+                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
+                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
+                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
+                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5);
+                        s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
+                    in s7 (arg v))
+" 
+          by metis
+        also have "\<dots> = s (arg v)" using ih  by (auto simp: arg_def x1)
+
+        finally show "(if map (\<lambda>i. s (arg i)) bs' = [] then state_transformer (''a'' @ p) [(b', 0)] \<circ> state_transformer p [(''cons_list'', s (arg b'))]
+        else (\<lambda>s0. let s1 = cons_list_IMP_Minus_state_transformer p (map (\<lambda>i. s (arg i)) bs') bs' s0;
+                        s2 = s1(add_prefix (''b'' @ p) ''a'' := aval (aexp_add_prefix (''a'' @ p) (A (V b'))) s1);
+                        s3 = s2(add_prefix (''b'' @ p) ''b'' := aval (aexp_add_prefix p (A (V ''cons_list''))) s2);
+                        s4 = cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3;
+                        s5 = s4(add_prefix p ''cons_list'' := aval (aexp_add_prefix (''b'' @ p) (A (V ''cons''))) s4);
+                        s6 = s5(add_prefix (''b'' @ p) ''cons'' := aval (aexp_add_prefix p (A (N 0))) s5); s7 = s6(add_prefix (''a'' @ p) b' := aval (aexp_add_prefix p (A (N 0))) s6)
+                    in s7))
+        s (arg v) =
+       s (arg v)" by simp
+      qed
+    qed
+
+    then have c1: "(s3 (add_prefix (''b'' @ p) ''a'')) = (s (arg v))"
+      by (auto simp: s3_def s2_def s1_def arg_def)
 
     show ?thesis
       apply(subst arg_def[symmetric])+

--- a/IMP-/IMP_Minus_Nat_Bijection.thy
+++ b/IMP-/IMP_Minus_Nat_Bijection.thy
@@ -285,9 +285,9 @@ fun cons_list :: "nat list \<Rightarrow> nat" where
 fun cons_list_IMP_Minus_time :: "nat list \<Rightarrow> nat" where
 "cons_list_IMP_Minus_time [] = 1" | 
 "cons_list_IMP_Minus_time (a # as) = 
-  (if as = [] 
+  (if as = []
    then 4
-   else cons_list_IMP_Minus_time as + 2 + 2 + cons_IMP_Minus_time a (cons_list as)) + 2 + 2 + 2"
+   else cons_list_IMP_Minus_time as + 2 + 2 + cons_IMP_Minus_time a (cons_list as) + 2 + 2 + 2)"
 
 (*
 fun cons_list_IMP_Minus_state_transformer where 
@@ -390,7 +390,7 @@ proof(induct vs)
         "\<lambda> s2. state_transformer (''b'' @ p) [(''b'', s2 (add_prefix p ''cons_list''))] s2"
         "\<lambda> s3. cons_IMP_Minus_state_transformer (''b'' @ p) (s3 (add_prefix (''b'' @ p) ''a'')) (s3 (add_prefix (''b'' @ p) ''b'')) s3"
         "\<lambda> s4. state_transformer p [(''cons_list'', s4 (add_prefix (''b'' @ p) ''cons''))] s4"
-        "state_transformer (''b'' @ p) [(''cons'', 0)]" "state_transformer (''a'' @ p) [(b', 0)]" "ar v"] 
+        "state_transformer (''b'' @ p) [(''cons'', 0)]" "state_transformer (''a'' @ p) [(b', 0)]" ] 
     by (auto simp: arg_def)
 qed simp
 
@@ -407,10 +407,7 @@ proof(induction vs arbitrary: s)
   proof (cases vs)
     case Nil
     then show ?thesis
-      apply(auto
-          simp: state_transformer_commutes'
-          intro!: terminates_in_time_state_intro[OF Seq'])
-      sorry
+      by(auto intro!: terminates_in_time_state_intro[OF Seq'])
   next
     case ConsB: (Cons b bs)
     define arg where "arg \<equiv> add_prefix (''a'' @ p)"

--- a/IMP-/IMP_Minus_Nat_Bijection.thy
+++ b/IMP-/IMP_Minus_Nat_Bijection.thy
@@ -289,40 +289,6 @@ fun cons_list_IMP_Minus_time :: "nat list \<Rightarrow> nat" where
    then 4
    else cons_list_IMP_Minus_time as + 2 + 2 + cons_IMP_Minus_time a (cons_list as) + 2 + 2 + 2)"
 
-(*
-fun cons_list_IMP_Minus_state_transformer where 
-  "cons_list_IMP_Minus_state_transformer p [] vs = (\<lambda>s. s)" |
-  "cons_list_IMP_Minus_state_transformer p (a # as) (v#vs) = (if as = [] then
-    state_transformer p [(''cons_list'', a)]
-    else
-      state_transformer p [(''cons_list'', cons_list (a # as))]
-      \<circ> cons_IMP_Minus_state_transformer (''b'' @ p) a (cons_list as)
-    )
-    \<circ> state_transformer (''a'' @ p) [(v, 0)]"
-*)
-(*
-fun cons_list_IMP_Minus_state_transformer where 
-  "cons_list_IMP_Minus_state_transformer p [] vs = (\<lambda>s. s)" |
-  "cons_list_IMP_Minus_state_transformer p (a # as) (v#vs) = (if as = [] then
-    state_transformer (''a'' @ p) [(v, 0)]
-  \<circ> state_transformer p [(''cons_list'', a)]
-    else
-      let cons_list_s = cons_list_IMP_Minus_state_transformer p as vs ;
-          b_a_assign = state_transformer (''b'' @ p) [(''a'', a)] ;
-          b_b_assign = state_transformer (''b'' @ p) [(''b'', cons_list as)];
-          cons_sub = cons_IMP_Minus_state_transformer (''b'' @ p) a (cons_list as) ;
-          cons_list_assign = state_transformer p [(''cons_list'', cons a (cons_list as) )];
-          b_cons_assign = state_transformer (''b'' @ p) [(''cons'',0)] ;
-          a_a_assign = state_transformer (''a'' @ p) [(v, 0)]
-  in a_a_assign \<circ> b_cons_assign
-    \<circ> cons_list_assign
-    \<circ> cons_sub
-    \<circ> b_b_assign
-    \<circ> b_a_assign
-    \<circ> cons_list_s
-  )
-"
-*)
 fun cons_list_IMP_Minus_state_transformer where 
   "cons_list_IMP_Minus_state_transformer p [] vs = (\<lambda>s. s)" |
   "cons_list_IMP_Minus_state_transformer p (a # as) (v#vs) = (if as = [] then
@@ -340,34 +306,6 @@ fun cons_list_IMP_Minus_state_transformer where
   in s7 )
   )
 "
-
-(*
-fun cons_list_IMP_Minus_state_transformer where 
-  "cons_list_IMP_Minus_state_transformer p [] vs = (\<lambda>s. s)" |
-  "cons_list_IMP_Minus_state_transformer p (a # as) (v#vs) = (if as = [] then
-    state_transformer p [(''cons_list'', a)]
-    else
-      let cons_list_rec = cons_list_IMP_Minus_state_transformer p as vs ;
-          b_a_var = a ;
-          s2 = state_transformer (''b'' @ p) [(''a'', b_a_var)] ;
-          b_b_var = cons_list_rec ;
-          cons_var = cons a cons_list_rec ;
-          cons_list_var = cons_var ;
-          cons_var = 0 ;
-          a_a_var = 0
-  in
-    state_transformer (''b'' @ p) [(''a'', b_a_var)]  
-    o
-    cons_list_rec
-  )
-"
-*)
-(*
-      state_transformer p [(''cons_list'', cons_list (a # as))]
-      \<circ> cons_IMP_Minus_state_transformer (''b'' @ p) a (cons_list as)
-    )
-    \<circ> state_transformer (''a'' @ p) [(v, 0)]"
-*)
 
 lemma auxxx: "(let s1 = t1; s2 = t2 s1; s3 = t3 s2; s4 = t4 s3;
                 s5 = t5 s4; s6 = t6 s5; s7 = t7 s6 in s7) a

--- a/IMP-/IMP_Minus_Nat_Bijection.thy
+++ b/IMP-/IMP_Minus_Nat_Bijection.thy
@@ -322,6 +322,9 @@ proof(induction vs arbitrary: s)
   proof (cases vs)
     case Nil
     then show ?thesis
+      apply(auto
+          simp: state_transformer_commutes'
+          intro!: terminates_in_time_state_intro[OF Seq'])
       sorry
   next
     case ConsB: (Cons b bs)


### PR DESCRIPTION
Two files changed, IMP_Minus_Nat_Bijection.thy and IMP_Minus_Common_Funs_Nat.thy, the latter being a continuation of the former (could be merged into one file);
currently, everything from the last (*reverse_nat*) section in IMP_Minus_Nat_Bijection.thy onwards is not transformed into *pcom* and thus erroneous (and basically the whole file IMP_Minus_Common_Funs_Nat.thy being commented out), but the problems (i.e. the concrete errors) should be technical, i.e. the proofs themselves correct